### PR TITLE
Role distinction

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,17 +17,6 @@
       "test"
     ]
   },
-  "standard": {
-    "globals": [
-      "afterAll",
-      "beforeAll",
-      "beforeEach",
-      "describe",
-      "expect",
-      "jest",
-      "test"
-    ]
-  },
   "dependencies": {
     "dotenv": "^17.4.2",
     "ejs": "^3.1.10",

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const express = require('express')
+const institutionSearchRouter = require('./routes/institution_search')
 const loginRouter = require('./routes/login')
 const registerRouter = require('./routes/register')
 const homeRouter = require('./routes/home')
@@ -12,6 +13,7 @@ APP.set('views', path.join(__dirname, 'views'))
 
 APP.use(express.urlencoded({ extended: true }))
 APP.use(express.static(path.join(__dirname, 'public'))) // css style template
+APP.use('/institutions', institutionSearchRouter)
 APP.use('/login', loginRouter)
 APP.use('/register', registerRouter)
 APP.use('/home', homeRouter)

--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,8 @@ const path = require('path')
 const express = require('express')
 const loginRouter = require('./routes/login')
 const registerRouter = require('./routes/register')
-
+const homeRouter = require('./routes/home')
+const userProfileRouter = require('./routes/user_profile')
 const APP = express()
 const PORT = process.env.PORT || 8080
 
@@ -13,17 +14,12 @@ APP.use(express.urlencoded({ extended: true }))
 APP.use(express.static(path.join(__dirname, 'public'))) // css style template
 APP.use('/login', loginRouter)
 APP.use('/register', registerRouter)
-
+APP.use('/home', homeRouter)
+APP.use('/user_profile', userProfileRouter)
 // entry-point is login page. This can be changed when authentication between pages is added
+
 APP.get('/', (req, res) => {
   res.redirect('/login')
-})
-
-// does nothing atm
-APP.get('/home', (req, res) => {
-  res.render('home', {
-    title: 'Home'
-  })
 })
 
 if (require.main === module) {

--- a/src/app.js
+++ b/src/app.js
@@ -5,29 +5,29 @@ const loginRouter = require('./routes/login')
 const registerRouter = require('./routes/register')
 const homeRouter = require('./routes/home')
 const userProfileRouter = require('./routes/user_profile')
-const APP = express()
+const app = express()
 const PORT = process.env.PORT || 8080
 
-APP.set('view engine', 'ejs')
-APP.set('views', path.join(__dirname, 'views'))
+app.set('view engine', 'ejs')
+app.set('views', path.join(__dirname, 'views'))
 
-APP.use(express.urlencoded({ extended: true }))
-APP.use(express.static(path.join(__dirname, 'public'))) // css style template
-APP.use('/institutions', institutionSearchRouter)
-APP.use('/login', loginRouter)
-APP.use('/register', registerRouter)
-APP.use('/home', homeRouter)
-APP.use('/user_profile', userProfileRouter)
+app.use(express.urlencoded({ extended: true }))
+app.use(express.static(path.join(__dirname, 'public'))) // css style template
+app.use('/institutions', institutionSearchRouter)
+app.use('/login', loginRouter)
+app.use('/register', registerRouter)
+app.use('/home', homeRouter)
+app.use('/user_profile', userProfileRouter)
 // entry-point is login page. This can be changed when authentication between pages is added
 
-APP.get('/', (req, res) => {
+app.get('/', (req, res) => {
   res.redirect('/login')
 })
 
 if (require.main === module) {
-  APP.listen(PORT, () => {
+  app.listen(PORT, () => {
     console.log(`App listening at http://localhost:${PORT}`)
   })
 }
 
-module.exports = APP
+module.exports = app

--- a/src/models/university_db.js
+++ b/src/models/university_db.js
@@ -17,6 +17,38 @@ const schoolsCollection = function () {
   return getCollection(SCHOOL_COLLECTION_NAME)
 }
 
+const escapeRegularExpression = function (value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// cleans user input text to query against institution collections
+const searchByName = async function (collection, query, { filters = {}, limit = 10 } = {}) {
+  const normalizedQuery = query?.trim() || ''
+
+  if (!normalizedQuery) {
+    return []
+  }
+  return collection
+    .find(
+      {
+        ...filters,
+        name: {
+          $regex: escapeRegularExpression(normalizedQuery), // ignore regexes
+          $options: 'i' // case-insensitive for querying
+        }
+      },
+      {
+        projection: {
+          _id: 0, // to ONLY return the name - not the rest of the entries
+          name: 1
+        }
+      }
+    )
+    .sort({ name: 1 }) // returns alphabetised list
+    .limit(limit)
+    .toArray()
+}
+
 /**
  * Converts a supported value into a MongoDB ObjectId.
  * @param {string|import('mongodb').ObjectId} value - Value to convert.
@@ -26,11 +58,9 @@ const toObjectId = function (value) {
   if (value instanceof ObjectId) {
     return value
   }
-
   if (typeof value === 'string' && ObjectId.isValid(value)) {
     return new ObjectId(value)
   }
-
   return null
 }
 
@@ -41,7 +71,6 @@ const idsMatch = function (left, right) {
   if (!leftId || !rightId) {
     return false
   }
-
   return leftId.equals(rightId)
 }
 
@@ -57,15 +86,12 @@ const findByIdOrName = async function (collection, value) {
   if (documentId) {
     return collection.findOne({ _id: documentId })
   }
-
   if (value && typeof value === 'object') {
     return value
   }
-
   if (typeof value === 'string') {
     return collection.findOne({ name: value })
   }
-
   return null
 }
 
@@ -76,6 +102,60 @@ const findByIdOrName = async function (collection, value) {
  */
 const getUniversity = async function (university) {
   return findByIdOrName(universitiesCollection(), university)
+}
+
+/**
+ * Returns universities whose names match a partial query.
+ * @param {string} query - Partial university name to search for.
+ * @param {number} [limit=10] - Maximum number of results to return.
+ * @returns {Promise<Array<{name: string}>>} Matching universities.
+ */
+const searchUniversities = async function (query, limit = 10) {
+  return searchByName(universitiesCollection(), query, { limit })
+}
+
+/**
+ * Returns faculties whose names match a partial query.
+ * @param {string} query - Partial faculty name to search for.
+ * @param {object} [options={}] - Optional faculty search filters.
+ * @param {string} [options.university=''] - University name to filter faculties by.
+ * @param {number} [options.limit=10] - Maximum number of results to return.
+ * @returns {Promise<Array<{name: string}>>} Matching faculties.
+ */
+const searchFaculties = async function (query, { university = '', limit = 10 } = {}) {
+  const filters = {}
+
+  if (university) {
+    filters.universityName = university
+  }
+  return searchByName(facultiesCollection(), query, {
+    filters,
+    limit
+  })
+}
+
+/**
+ * Returns schools whose names match a partial query.
+ * @param {string} query - Partial school name to search for.
+ * @param {object} [options={}] - Optional school search filters.
+ * @param {string} [options.university=''] - University name to filter schools by.
+ * @param {string} [options.faculty=''] - Faculty name to filter schools by.
+ * @param {number} [options.limit=10] - Maximum number of results to return.
+ * @returns {Promise<Array<{name: string}>>} Matching schools.
+ */
+const searchSchools = async function (query, { university = '', faculty = '', limit = 10 } = {}) {
+  const filters = {}
+
+  if (university) {
+    filters.universityName = university
+  }
+  if (faculty) {
+    filters.facultyName = faculty
+  }
+  return searchByName(schoolsCollection(), query, {
+    filters,
+    limit
+  })
 }
 
 /**
@@ -109,7 +189,6 @@ const isFacultyInUniversity = async function (faculty, university) {
   if (!facultyDocument || !universityDocument) {
     return false
   }
-
   return idsMatch(facultyDocument.universityID, universityDocument._id)
 }
 
@@ -126,7 +205,6 @@ const isSchoolInFaculty = async function (school, faculty) {
   if (!schoolDocument || !facultyDocument) {
     return false
   }
-
   return idsMatch(schoolDocument.facultyID, facultyDocument._id)
 }
 
@@ -134,6 +212,9 @@ module.exports = {
   getFaculty,
   getSchool,
   getUniversity,
+  searchFaculties,
+  searchSchools,
+  searchUniversities,
   isFacultyInUniversity,
   isSchoolInFaculty
 }

--- a/src/models/university_db.js
+++ b/src/models/university_db.js
@@ -189,7 +189,7 @@ const isFacultyInUniversity = async function (faculty, university) {
   if (!facultyDocument || !universityDocument) {
     return false
   }
-  return idsMatch(facultyDocument.universityID, universityDocument._id)
+  return idsMatch(facultyDocument.universityId, universityDocument._id)
 }
 
 /**
@@ -205,7 +205,7 @@ const isSchoolInFaculty = async function (school, faculty) {
   if (!schoolDocument || !facultyDocument) {
     return false
   }
-  return idsMatch(schoolDocument.facultyID, facultyDocument._id)
+  return idsMatch(schoolDocument.facultyId, facultyDocument._id)
 }
 
 module.exports = {

--- a/src/models/user_db.js
+++ b/src/models/user_db.js
@@ -25,6 +25,32 @@ const addUser = async function (user) {
 }
 
 /**
+ * Updates a user's institution fields by username.
+ * @param {string} username - Username to update.
+ * @param {object} institutions - Institution fields to store.
+ * @param {string} institutions.universityId - Updated university value.
+ * @param {string} institutions.facultyId - Updated faculty value.
+ * @param {string} institutions.schoolId - Updated school value.
+ * @returns {Promise<import('mongodb').UpdateResult>} MongoDB update result.
+ */
+const updateUserInstitutions = async function (username, {
+  universityId,
+  facultyId,
+  schoolId
+}) {
+  return usersCollection().updateOne(
+    { username },
+    {
+      $set: {
+        universityId,
+        facultyId,
+        schoolId
+      }
+    }
+  )
+}
+
+/**
  * Deletes a user document by username.
  * @param {string} username - Username to delete.
  * @returns {Promise<import('mongodb').DeleteResult>} MongoDB delete result.
@@ -36,5 +62,6 @@ const deleteUser = async function (username) {
 module.exports = {
   addUser,
   deleteUser,
-  getUser
+  getUser,
+  updateUserInstitutions
 }

--- a/src/public/scripts/search.js
+++ b/src/public/scripts/search.js
@@ -1,0 +1,174 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const searchInputs = Array.from(document.querySelectorAll('[data-search-url]'))
+
+  if (searchInputs.length === 0) {
+    return
+  }
+  const searchStates = new Map()
+
+  const getStatusElement = function (input) {
+    const describedBy = input.getAttribute('aria-describedby')
+    return describedBy ? document.getElementById(describedBy) : null
+  }
+
+  const getOptionsElement = function (input) {
+    const optionsListId = input.getAttribute('list')
+    return optionsListId ? document.getElementById(optionsListId) : null
+  }
+
+  const getSearchParents = function (input) {
+    return (input.dataset.searchParents || '')
+      .split(',')
+      .map(function (fieldName) {
+        return fieldName.trim()
+      })
+      .filter(Boolean)
+  }
+
+  const buildInvalidSelectionMessage = function (input) {
+    const fieldLabel = input.dataset.searchLabel || input.name || 'value'
+
+    return `Invalid ${fieldLabel} selection.`
+  }
+
+  const renderOptions = function (input, results) {
+    const optionsElement = getOptionsElement(input)
+
+    if (!optionsElement) {
+      return
+    }
+
+    while (optionsElement.firstChild) {
+      optionsElement.removeChild(optionsElement.firstChild)
+    }
+
+    results.forEach(function (universityName) {
+      const option = document.createElement('option')
+      option.value = universityName
+      optionsElement.appendChild(option)
+    })
+  }
+
+  const applyResults = function (input, query, results) {
+    const statusElement = getStatusElement(input)
+    const searchState = searchStates.get(input)
+
+    if (!statusElement || !searchState) {
+      return
+    }
+
+    searchState.latestResults = results
+    renderOptions(input, results)
+
+    if (!query) {
+      statusElement.textContent = ''
+      input.setCustomValidity('')
+      return
+    }
+
+    if (results.length === 0) {
+      statusElement.textContent = 'No results found'
+      input.setCustomValidity(buildInvalidSelectionMessage(input))
+      return
+    }
+
+    statusElement.textContent = ''
+    input.setCustomValidity('')
+  }
+
+  const searchValues = async function (input, query) {
+    const normalizedQuery = query.trim()
+    const searchState = searchStates.get(input)
+    const searchParameters = new URLSearchParams({ query: normalizedQuery })
+
+    searchState.searchRequestNumber += 1
+    const currentSearchRequestNumber = searchState.searchRequestNumber
+
+    getSearchParents(input).forEach(function (parentFieldName) {
+      const parentInput = document.querySelector(`[name="${parentFieldName}"]`)
+      const parentValue = parentInput?.value?.trim() || ''
+
+      if (parentValue) {
+        searchParameters.set(parentFieldName, parentValue)
+      }
+    })
+
+    if (!normalizedQuery) {
+      applyResults(input, '', [])
+      return
+    }
+
+    try {
+      const response = await fetch(
+        `${input.dataset.searchUrl}?${searchParameters.toString()}`,
+        {
+          headers: {
+            Accept: 'application/json'
+          }
+        }
+      )
+
+      if (!response.ok) {
+        throw new Error('University search request failed.')
+      }
+
+      const responseBody = await response.json()
+
+      if (currentSearchRequestNumber !== searchState.searchRequestNumber) {
+        return
+      }
+
+      applyResults(
+        input,
+        normalizedQuery,
+        Array.isArray(responseBody.results) ? responseBody.results : []
+      )
+    } catch (error) {
+      if (currentSearchRequestNumber !== searchState.searchRequestNumber) {
+        return
+      }
+
+      applyResults(input, normalizedQuery, [])
+    }
+  }
+
+  searchInputs.forEach(function (input) {
+    searchStates.set(input, {
+      latestResults: [],
+      searchRequestNumber: 0
+    })
+
+    input.addEventListener('input', function (event) {
+      searchValues(input, event.target.value)
+    })
+
+    input.addEventListener('change', function () {
+      const searchState = searchStates.get(input)
+      const selectedValue = input.value.trim()
+
+      if (!selectedValue || searchState.latestResults.includes(selectedValue)) {
+        input.setCustomValidity('')
+        return
+      }
+
+      input.setCustomValidity(buildInvalidSelectionMessage(input))
+    })
+
+    getSearchParents(input).forEach(function (parentFieldName) {
+      const parentInput = document.querySelector(`[name="${parentFieldName}"]`)
+
+      if (!parentInput) {
+        return
+      }
+
+      parentInput.addEventListener('change', function () {
+        input.value = ''
+        applyResults(input, '', [])
+      })
+    })
+
+    if (input.value.trim()) {
+      searchValues(input, input.value)
+    }
+  })
+})

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -49,6 +49,10 @@ body {
   max-width: 640px;
 }
 
+.card_even_wider {
+  max-width: 860px;
+}
+
 .text_center {
   text-align: center;
 }
@@ -66,13 +70,25 @@ label {
   display: grid;
   gap: 8px;
   font-weight: 600;
+  position: relative;
+  padding-bottom: 1.1rem;
 }
 
 input {
-  padding: 12px;
+  padding: 14px;
   border: 1px solid var(--color-border);
   border-radius: 8px;
   font-size: 1rem;
+  margin: 0;
+}
+
+select {
+  padding: 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  font-size: 1rem;
+  background-color: var(--color-surface);
+  margin: 0;
 }
 
 button,
@@ -96,7 +112,37 @@ a {
   color: var(--color-error-text);
 }
 
+.search_status {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  margin: 0;
+  color: var(--color-secondary);
+  font-size: 0.8rem;
+  line-height: 1rem;
+}
+
 .back_link {
   margin-top: 16px;
   background: var(--color-secondary);
+}
+
+.register_columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 16px;
+}
+
+.register_left_column,
+.register_middle_column,
+.register_right_column {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+@media (max-width: 640px) {
+  .register_columns {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -141,8 +141,45 @@ a {
   align-content: start;
 }
 
+.profile_details {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  max-width: 760px;
+  margin: 24px auto 0;
+  text-align: left;
+}
+
+.profile_column {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+.profile_detail {
+  padding: 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-surface);
+}
+
+.profile_detail_label {
+  margin: 0 0 4px;
+  color: var(--color-secondary);
+  font-size: 0.9rem;
+}
+
+.profile_detail_value {
+  margin: 0;
+  font-size: 1rem;
+}
+
 @media (max-width: 640px) {
   .register_columns {
+    grid-template-columns: 1fr;
+  }
+
+  .profile_details {
     grid-template-columns: 1fr;
   }
 }

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -156,6 +156,14 @@ a {
   align-content: start;
 }
 
+.profile_update_form {
+  padding: 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-surface);
+  text-align: left;
+}
+
 .profile_detail {
   padding: 14px;
   border: 1px solid var(--color-border);

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -1,0 +1,13 @@
+const express = require('express')
+
+const ROUTER = express.Router()
+
+ROUTER.get('/', (req, res) => {
+  const username = req.query.username?.trim() || ''
+  res.render('home', {
+    title: 'Home',
+    username
+  })
+})
+
+module.exports = ROUTER

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -1,8 +1,8 @@
 const express = require('express')
 
-const ROUTER = express.Router()
+const router = express.Router()
 
-ROUTER.get('/', (req, res) => {
+router.get('/', (req, res) => {
   const username = req.query.username?.trim() || ''
   res.render('home', {
     title: 'Home',
@@ -10,4 +10,4 @@ ROUTER.get('/', (req, res) => {
   })
 })
 
-module.exports = ROUTER
+module.exports = router

--- a/src/routes/institution_search.js
+++ b/src/routes/institution_search.js
@@ -6,10 +6,10 @@ const {
   searchUniversities
 } = require('../models/university_db')
 
-const ROUTER = express.Router()
+const router = express.Router()
 const INSTITUTION_SEARCH_LIMIT = 8
 
-ROUTER.get('/universities', async (req, res) => {
+router.get('/universities', async (req, res) => {
   const query = req.query.query?.trim() || ''
 
   if (!query) {
@@ -31,7 +31,7 @@ ROUTER.get('/universities', async (req, res) => {
   }
 })
 
-ROUTER.get('/faculties', async (req, res) => {
+router.get('/faculties', async (req, res) => {
   const query = req.query.query?.trim() || ''
   const university = req.query.university?.trim() || ''
 
@@ -57,7 +57,7 @@ ROUTER.get('/faculties', async (req, res) => {
   }
 })
 
-ROUTER.get('/schools', async (req, res) => {
+router.get('/schools', async (req, res) => {
   const query = req.query.query?.trim() || ''
   const university = req.query.university?.trim() || ''
   const faculty = req.query.faculty?.trim() || ''
@@ -85,4 +85,4 @@ ROUTER.get('/schools', async (req, res) => {
   }
 })
 
-module.exports = ROUTER
+module.exports = router

--- a/src/routes/institution_search.js
+++ b/src/routes/institution_search.js
@@ -1,0 +1,88 @@
+const express = require('express')
+const { connectToDatabase } = require('../models/db')
+const {
+  searchFaculties,
+  searchSchools,
+  searchUniversities
+} = require('../models/university_db')
+
+const ROUTER = express.Router()
+const INSTITUTION_SEARCH_LIMIT = 8
+
+ROUTER.get('/universities', async (req, res) => {
+  const query = req.query.query?.trim() || ''
+
+  if (!query) {
+    return res.json({ results: [] })
+  }
+
+  try {
+    await connectToDatabase()
+    const universities = await searchUniversities(query, INSTITUTION_SEARCH_LIMIT)
+
+    return res.json({
+      results: universities.map((universityDocument) => universityDocument.name)
+    })
+  } catch (error) {
+    return res.status(500).json({
+      error: 'Sorry. We can not search universities right now.',
+      results: []
+    })
+  }
+})
+
+ROUTER.get('/faculties', async (req, res) => {
+  const query = req.query.query?.trim() || ''
+  const university = req.query.university?.trim() || ''
+
+  if (!query) {
+    return res.json({ results: [] })
+  }
+
+  try {
+    await connectToDatabase()
+    const faculties = await searchFaculties(query, {
+      limit: INSTITUTION_SEARCH_LIMIT,
+      university
+    })
+
+    return res.json({
+      results: faculties.map((facultyDocument) => facultyDocument.name)
+    })
+  } catch (error) {
+    return res.status(500).json({
+      error: 'Sorry. We can not search faculties right now.',
+      results: []
+    })
+  }
+})
+
+ROUTER.get('/schools', async (req, res) => {
+  const query = req.query.query?.trim() || ''
+  const university = req.query.university?.trim() || ''
+  const faculty = req.query.faculty?.trim() || ''
+
+  if (!query) {
+    return res.json({ results: [] })
+  }
+
+  try {
+    await connectToDatabase()
+    const schools = await searchSchools(query, {
+      faculty,
+      limit: INSTITUTION_SEARCH_LIMIT,
+      university
+    })
+
+    return res.json({
+      results: schools.map((schoolDocument) => schoolDocument.name)
+    })
+  } catch (error) {
+    return res.status(500).json({
+      error: 'Sorry. We could not search schools right now.',
+      results: []
+    })
+  }
+})
+
+module.exports = ROUTER

--- a/src/routes/login.js
+++ b/src/routes/login.js
@@ -3,7 +3,7 @@ const { connectToDatabase } = require('../models/db')
 const { getUser } = require('../models/user_db')
 const { verifyPassword } = require('../utils/password')
 
-const ROUTER = express.Router()
+const router = express.Router()
 
 /**
  * Renders the login page with the supplied view state.
@@ -22,11 +22,11 @@ const renderLogin = function (res, { statusCode = 200, error = '', username = ''
   })
 }
 
-ROUTER.get('/', (req, res) => {
+router.get('/', (req, res) => {
   return renderLogin(res)
 })
 
-ROUTER.post('/', async (req, res) => {
+router.post('/', async (req, res) => {
   const username = req.body.username?.trim() || ''
   const password = req.body.password || ''
 
@@ -57,7 +57,7 @@ ROUTER.post('/', async (req, res) => {
       })
     }
 
-    return res.redirect('/home?username=' + encodeURIComponent(username))
+    return res.redirect(`/home?username=${encodeURIComponent(username)}`)
   } catch (error) {
     return renderLogin(res, {
       statusCode: 500,
@@ -67,4 +67,4 @@ ROUTER.post('/', async (req, res) => {
   }
 })
 
-module.exports = ROUTER
+module.exports = router

--- a/src/routes/login.js
+++ b/src/routes/login.js
@@ -57,7 +57,7 @@ ROUTER.post('/', async (req, res) => {
       })
     }
 
-    return res.redirect('/home')
+    return res.redirect('/home?username=' + encodeURIComponent(username))
   } catch (error) {
     return renderLogin(res, {
       statusCode: 500,

--- a/src/routes/register.js
+++ b/src/routes/register.js
@@ -3,7 +3,7 @@ const { connectToDatabase } = require('../models/db')
 const { addUser } = require('../models/user_db')
 const { validateSelection } = require('../services/institution_validation')
 const { hashPassword } = require('../utils/password')
-const ROUTER = express.Router()
+const router = express.Router()
 const BASIC_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const PLACEHOLDER_USER_FIELDS = Object.freeze({
@@ -89,11 +89,11 @@ const buildUser = async function ({
   }
 }
 
-ROUTER.get('/', (req, res) => {
+router.get('/', (req, res) => {
   return renderRegister(res)
 })
 
-ROUTER.post('/', async (req, res) => {
+router.post('/', async (req, res) => {
   const emailAddress = req.body.emailAddress?.trim() || ''
   const username = req.body.username?.trim() || ''
   const password = req.body.password || ''
@@ -175,4 +175,4 @@ ROUTER.post('/', async (req, res) => {
   }
 })
 
-module.exports = ROUTER
+module.exports = router

--- a/src/routes/register.js
+++ b/src/routes/register.js
@@ -1,17 +1,24 @@
 const express = require('express')
 const { connectToDatabase } = require('../models/db')
+const {
+  getFaculty,
+  getSchool,
+  getUniversity,
+  searchFaculties,
+  searchSchools,
+  searchUniversities,
+  isFacultyInUniversity,
+  isSchoolInFaculty
+} = require('../models/university_db')
 const { addUser } = require('../models/user_db')
 const { hashPassword } = require('../utils/password')
 const ROUTER = express.Router()
 const BASIC_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const INSTITUTION_SEARCH_LIMIT = 8 // arbitrary
 
 const PLACEHOLDER_USER_FIELDS = Object.freeze({
   facultyId: 'unassigned',
-  firstName: 'Pending',
-  lastName: 'Pending',
-  role: 'student',
-  schoolId: 'unassigned',
-  universityId: 'unassigned'
+  schoolId: 'unassigned'
 })
 
 /**
@@ -22,14 +29,37 @@ const PLACEHOLDER_USER_FIELDS = Object.freeze({
  * @param {string} [options.error=''] - Error message to show in the view.
  * @param {string} [options.emailAddress=''] - Email address to preserve in the form.
  * @param {string} [options.username=''] - Username to preserve in the form.
+ * @param {string} [options.university=''] - University to preserve in the form.
+ * @param {string} [options.faculty=''] - Faculty to preserve in the form.
+ * @param {string} [options.school=''] - School to preserve in the form.
+ * @param {string} [options.role=''] - Role to preserve in the form.
+ * @param {string} [options.name=''] - First name(s) to preserve in the form.
+ * @param {string} [options.surname=''] - Surname to preserve in the form.
  * @returns {import('express').Response} The rendered response.
  */
-const renderRegister = function (res, { statusCode = 200, error = '', emailAddress = '', username = '' } = {}) {
+const renderRegister = function (res, {
+  statusCode = 200,
+  error = '',
+  emailAddress = '',
+  username = '',
+  university = '',
+  faculty = '',
+  school = '',
+  role = '',
+  name = '',
+  surname = ''
+} = {}) {
   return res.status(statusCode).render('register', {
     title: 'Register',
     error,
     emailAddress,
-    username
+    username,
+    university,
+    faculty,
+    school,
+    role,
+    name,
+    surname
   })
 }
 
@@ -39,16 +69,111 @@ const renderRegister = function (res, { statusCode = 200, error = '', emailAddre
  * @param {string} input.emailAddress - Raw email address from the request.
  * @param {string} input.password - Raw password from the request.
  * @param {string} input.username - Username from the request.
+ * @param {string} [input.university=''] - University from the request.
+ * @param {string} [input.faculty=''] - Faculty from the request -optional.
+ * @param {string} [input.school=''] - School from the request -optional
+ * @param {string} [input.role=''] - Role from the request.
  * @returns {Promise<object>} The user document ready for insertion.
  */
-const buildUser = async function ({ emailAddress, password, username }) {
+const buildUser = async function ({
+  emailAddress,
+  password,
+  username,
+  name,
+  surname,
+  university = '',
+  faculty = '',
+  school = '',
+  role = ''
+}) {
   return {
-    ...PLACEHOLDER_USER_FIELDS,
+    lastName: surname,
+    firstName: name,
+    role: role.toLowerCase(),
+    schoolId: school || PLACEHOLDER_USER_FIELDS.schoolId,
+    facultyId: faculty || PLACEHOLDER_USER_FIELDS.facultyId,
+    universityId: university,
     email: emailAddress.toLowerCase(),
     passwordHash: await hashPassword(password),
     username
   }
 }
+
+ROUTER.get('/universities', async (req, res) => {
+  const query = req.query.query?.trim() || ''
+
+  if (!query) {
+    return res.json({ results: [] })
+  }
+
+  try {
+    await connectToDatabase()
+    const universities = await searchUniversities(query, INSTITUTION_SEARCH_LIMIT)
+
+    return res.json({
+      results: universities.map((universityDocument) => universityDocument.name)
+    })
+  } catch (error) {
+    return res.status(500).json({
+      error: 'Sorry. We can not search universities right now.',
+      results: []
+    })
+  }
+})
+
+ROUTER.get('/faculties', async (req, res) => {
+  const query = req.query.query?.trim() || ''
+  const university = req.query.university?.trim() || ''
+
+  if (!query) {
+    return res.json({ results: [] })
+  }
+
+  try {
+    await connectToDatabase()
+    const faculties = await searchFaculties(query, {
+      limit: INSTITUTION_SEARCH_LIMIT,
+      university
+    })
+
+    return res.json({
+      results: faculties.map((facultyDocument) => facultyDocument.name)
+    })
+  } catch (error) {
+    return res.status(500).json({
+      error: 'Sorry. We can not search faculties right now.',
+      results: []
+    })
+  }
+})
+
+ROUTER.get('/schools', async (req, res) => {
+  const query = req.query.query?.trim() || ''
+  const university = req.query.university?.trim() || ''
+  const faculty = req.query.faculty?.trim() || ''
+
+  if (!query) {
+    return res.json({ results: [] })
+  }
+
+  try {
+    await connectToDatabase()
+    const schools = await searchSchools(query, {
+      faculty,
+      limit: INSTITUTION_SEARCH_LIMIT,
+      university
+    })
+
+    return res.json({
+      results: schools.map((schoolDocument) => schoolDocument.name)
+    })
+  } catch (error) {
+    return res.status(500).json({
+      error: 'Sorry. We could not search schools right now.',
+      results: []
+    })
+  }
+})
 
 ROUTER.get('/', (req, res) => {
   return renderRegister(res)
@@ -58,13 +183,28 @@ ROUTER.post('/', async (req, res) => {
   const emailAddress = req.body.emailAddress?.trim() || ''
   const username = req.body.username?.trim() || ''
   const password = req.body.password || ''
+  const university = req.body.university?.trim() || ''
+  const faculty = req.body.faculty?.trim() || ''
+  const school = req.body.school?.trim() || ''
+  const role = req.body.role?.trim() || ''
+  const name = req.body.name?.trim() || ''
+  const surname = req.body.surname?.trim() || ''
+  const formValues = {
+    emailAddress,
+    username,
+    university,
+    faculty,
+    school,
+    role,
+    name,
+    surname
+  }
 
-  if (!emailAddress || !username || !password) {
+  if (!emailAddress || !username || !password || !university || !faculty || !school || !name || !surname || !role) {
     return renderRegister(res, {
       statusCode: 400,
-      error: 'Username, Email and Password are required.',
-      emailAddress,
-      username
+      error: 'Username, password, first/last names and institution credentials are required.',
+      ...formValues
     })
   }
 
@@ -72,30 +212,81 @@ ROUTER.post('/', async (req, res) => {
     return renderRegister(res, {
       statusCode: 400,
       error: 'Enter a valid email address.',
-      emailAddress,
-      username
+      ...formValues
     })
   }
-
+  // force user to enter valid institution
   try {
     await connectToDatabase()
-    await addUser(await buildUser({ emailAddress, password, username }))
+    const matchedUniversity = await getUniversity(university)
+    if (!matchedUniversity) {
+      return renderRegister(res, {
+        statusCode: 400,
+        error: 'University does not exist.',
+        ...formValues
+      })
+    }
+
+    const matchedFaculty = await getFaculty(faculty)
+    if (!matchedFaculty) {
+      return renderRegister(res, {
+        statusCode: 400,
+        error: 'Faculty does not exist.',
+        ...formValues
+      })
+    }
+
+    if (!(await isFacultyInUniversity(matchedFaculty, matchedUniversity))) {
+      return renderRegister(res, {
+        statusCode: 400,
+        error: 'Faculty not found in University.',
+        ...formValues
+      })
+    }
+
+    const matchedSchool = await getSchool(school)
+
+    if (!matchedSchool) {
+      return renderRegister(res, {
+        statusCode: 400,
+        error: 'School does not exist.',
+        ...formValues
+      })
+    }
+
+    if (!(await isSchoolInFaculty(matchedSchool, matchedFaculty))) {
+      return renderRegister(res, {
+        statusCode: 400,
+        error: 'School not found in Faculty.',
+        ...formValues
+      })
+    }
+
+    await addUser(await buildUser({
+      emailAddress,
+      password,
+      username,
+      name,
+      surname,
+      university,
+      faculty,
+      school,
+      role
+    }))
     return res.redirect('/login')
   } catch (error) {
     if (error?.code === 11000) {
       return renderRegister(res, {
         statusCode: 409,
-        error: 'That username is already taken.',
-        emailAddress,
-        username
+        error: 'Username is unavailable.',
+        ...formValues
       })
     }
 
     return renderRegister(res, {
       statusCode: 500,
       error: 'Sorry. We could not create your account. Try again later.',
-      emailAddress,
-      username
+      ...formValues
     })
   }
 })

--- a/src/routes/register.js
+++ b/src/routes/register.js
@@ -1,20 +1,10 @@
 const express = require('express')
 const { connectToDatabase } = require('../models/db')
-const {
-  getFaculty,
-  getSchool,
-  getUniversity,
-  searchFaculties,
-  searchSchools,
-  searchUniversities,
-  isFacultyInUniversity,
-  isSchoolInFaculty
-} = require('../models/university_db')
 const { addUser } = require('../models/user_db')
+const { validateSelection } = require('../services/institution_validation')
 const { hashPassword } = require('../utils/password')
 const ROUTER = express.Router()
 const BASIC_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-const INSTITUTION_SEARCH_LIMIT = 8 // arbitrary
 
 const PLACEHOLDER_USER_FIELDS = Object.freeze({
   facultyId: 'unassigned',
@@ -99,82 +89,6 @@ const buildUser = async function ({
   }
 }
 
-ROUTER.get('/universities', async (req, res) => {
-  const query = req.query.query?.trim() || ''
-
-  if (!query) {
-    return res.json({ results: [] })
-  }
-
-  try {
-    await connectToDatabase()
-    const universities = await searchUniversities(query, INSTITUTION_SEARCH_LIMIT)
-
-    return res.json({
-      results: universities.map((universityDocument) => universityDocument.name)
-    })
-  } catch (error) {
-    return res.status(500).json({
-      error: 'Sorry. We can not search universities right now.',
-      results: []
-    })
-  }
-})
-
-ROUTER.get('/faculties', async (req, res) => {
-  const query = req.query.query?.trim() || ''
-  const university = req.query.university?.trim() || ''
-
-  if (!query) {
-    return res.json({ results: [] })
-  }
-
-  try {
-    await connectToDatabase()
-    const faculties = await searchFaculties(query, {
-      limit: INSTITUTION_SEARCH_LIMIT,
-      university
-    })
-
-    return res.json({
-      results: faculties.map((facultyDocument) => facultyDocument.name)
-    })
-  } catch (error) {
-    return res.status(500).json({
-      error: 'Sorry. We can not search faculties right now.',
-      results: []
-    })
-  }
-})
-
-ROUTER.get('/schools', async (req, res) => {
-  const query = req.query.query?.trim() || ''
-  const university = req.query.university?.trim() || ''
-  const faculty = req.query.faculty?.trim() || ''
-
-  if (!query) {
-    return res.json({ results: [] })
-  }
-
-  try {
-    await connectToDatabase()
-    const schools = await searchSchools(query, {
-      faculty,
-      limit: INSTITUTION_SEARCH_LIMIT,
-      university
-    })
-
-    return res.json({
-      results: schools.map((schoolDocument) => schoolDocument.name)
-    })
-  } catch (error) {
-    return res.status(500).json({
-      error: 'Sorry. We could not search schools right now.',
-      results: []
-    })
-  }
-})
-
 ROUTER.get('/', (req, res) => {
   return renderRegister(res)
 })
@@ -215,49 +129,19 @@ ROUTER.post('/', async (req, res) => {
       ...formValues
     })
   }
-  // force user to enter valid institution
+
   try {
     await connectToDatabase()
-    const matchedUniversity = await getUniversity(university)
-    if (!matchedUniversity) {
-      return renderRegister(res, {
-        statusCode: 400,
-        error: 'University does not exist.',
-        ...formValues
-      })
-    }
+    const institutionValidation = await validateSelection({
+      faculty,
+      school,
+      university
+    })
 
-    const matchedFaculty = await getFaculty(faculty)
-    if (!matchedFaculty) {
+    if (!institutionValidation.isValid) {
       return renderRegister(res, {
-        statusCode: 400,
-        error: 'Faculty does not exist.',
-        ...formValues
-      })
-    }
-
-    if (!(await isFacultyInUniversity(matchedFaculty, matchedUniversity))) {
-      return renderRegister(res, {
-        statusCode: 400,
-        error: 'Faculty not found in University.',
-        ...formValues
-      })
-    }
-
-    const matchedSchool = await getSchool(school)
-
-    if (!matchedSchool) {
-      return renderRegister(res, {
-        statusCode: 400,
-        error: 'School does not exist.',
-        ...formValues
-      })
-    }
-
-    if (!(await isSchoolInFaculty(matchedSchool, matchedFaculty))) {
-      return renderRegister(res, {
-        statusCode: 400,
-        error: 'School not found in Faculty.',
+        statusCode: institutionValidation.statusCode,
+        error: institutionValidation.error,
         ...formValues
       })
     }
@@ -278,7 +162,7 @@ ROUTER.post('/', async (req, res) => {
     if (error?.code === 11000) {
       return renderRegister(res, {
         statusCode: 409,
-        error: 'Username is unavailable.',
+        error: 'That username is already taken.',
         ...formValues
       })
     }

--- a/src/routes/user_profile.js
+++ b/src/routes/user_profile.js
@@ -3,7 +3,7 @@ const { connectToDatabase } = require('../models/db')
 const { getUser, updateUserInstitutions } = require('../models/user_db')
 const { validateSelection } = require('../services/institution_validation')
 
-const ROUTER = express.Router()
+const router = express.Router()
 
 const renderProfile = function (res, {
   statusCode = 200,
@@ -51,7 +51,7 @@ const buildProfileViewState = function (user, overrides = {}) {
   }
 }
 
-ROUTER.get('/', async (req, res) => {
+router.get('/', async (req, res) => {
   const profileUsername = req.query.user?.trim() || req.query.username?.trim() || ''
   const viewer = req.query.viewer?.trim() || ''
 
@@ -84,7 +84,7 @@ ROUTER.get('/', async (req, res) => {
   }
 })
 
-ROUTER.post('/', async (req, res) => {
+router.post('/', async (req, res) => {
   const profileUsername = req.body.user?.trim() || req.body.username?.trim() || ''
   const viewer = req.body.viewer?.trim() || ''
   const university = req.body.university?.trim() || ''
@@ -165,4 +165,4 @@ ROUTER.post('/', async (req, res) => {
   }
 })
 
-module.exports = ROUTER
+module.exports = router

--- a/src/routes/user_profile.js
+++ b/src/routes/user_profile.js
@@ -1,0 +1,67 @@
+const express = require('express')
+const { connectToDatabase } = require('../models/db')
+const { getUser } = require('../models/user_db')
+
+const ROUTER = express.Router()
+
+const renderProfile = function (res, {
+  statusCode = 200,
+  error = '',
+  emailAddress = '',
+  username = '',
+  university = '',
+  faculty = '',
+  school = '',
+  role = '',
+  name = '',
+  surname = ''
+} = {}) {
+  return res.status(statusCode).render('user_profile', {
+    title: 'User Profile',
+    error,
+    emailAddress,
+    username,
+    university,
+    faculty,
+    school,
+    role,
+    name,
+    surname
+  })
+}
+
+ROUTER.get('/', async (req, res) => {
+  const username = req.query.username?.trim() || ''
+
+  if (!username) {
+    return res.redirect('/login')
+  }
+
+  try {
+    await connectToDatabase()
+    const user = await getUser(username)
+
+    if (!user) {
+      return res.redirect('/login')
+    }
+
+    return renderProfile(res, {
+      emailAddress: user.email,
+      username: user.username || username,
+      university: user.universityId,
+      faculty: user.facultyId,
+      school: user.schoolId,
+      role: user.role,
+      name: user.firstName,
+      surname: user.lastName
+    })
+  } catch (error) {
+    return renderProfile(res, {
+      statusCode: 500,
+      error: 'Sorry. We could not find user information.',
+      username
+    })
+  }
+})
+
+module.exports = ROUTER

--- a/src/routes/user_profile.js
+++ b/src/routes/user_profile.js
@@ -1,6 +1,7 @@
 const express = require('express')
 const { connectToDatabase } = require('../models/db')
-const { getUser } = require('../models/user_db')
+const { getUser, updateUserInstitutions } = require('../models/user_db')
+const { validateSelection } = require('../services/institution_validation')
 
 const ROUTER = express.Router()
 
@@ -9,6 +10,8 @@ const renderProfile = function (res, {
   error = '',
   emailAddress = '',
   username = '',
+  viewer = '',
+  canEdit = false,
   university = '',
   faculty = '',
   school = '',
@@ -21,6 +24,8 @@ const renderProfile = function (res, {
     error,
     emailAddress,
     username,
+    viewer,
+    canEdit,
     university,
     faculty,
     school,
@@ -30,36 +35,132 @@ const renderProfile = function (res, {
   })
 }
 
-ROUTER.get('/', async (req, res) => {
-  const username = req.query.username?.trim() || ''
+const buildProfileViewState = function (user, overrides = {}) {
+  return {
+    emailAddress: user?.email || '',
+    username: user?.username || '',
+    viewer: '',
+    canEdit: false,
+    university: user?.universityId || '',
+    faculty: user?.facultyId || '',
+    school: user?.schoolId || '',
+    role: user?.role || '',
+    name: user?.firstName || '',
+    surname: user?.lastName || '',
+    ...overrides
+  }
+}
 
-  if (!username) {
+ROUTER.get('/', async (req, res) => {
+  const profileUsername = req.query.user?.trim() || req.query.username?.trim() || ''
+  const viewer = req.query.viewer?.trim() || ''
+
+  if (!profileUsername) {
     return res.redirect('/login')
   }
 
   try {
     await connectToDatabase()
-    const user = await getUser(username)
+    const user = await getUser(profileUsername)
 
     if (!user) {
       return res.redirect('/login')
     }
 
-    return renderProfile(res, {
-      emailAddress: user.email,
-      username: user.username || username,
-      university: user.universityId,
-      faculty: user.facultyId,
-      school: user.schoolId,
-      role: user.role,
-      name: user.firstName,
-      surname: user.lastName
-    })
+    const resolvedUsername = user.username || profileUsername
+
+    return renderProfile(res, buildProfileViewState(user, {
+      canEdit: viewer === resolvedUsername,
+      username: resolvedUsername,
+      viewer
+    }))
   } catch (error) {
     return renderProfile(res, {
       statusCode: 500,
       error: 'Sorry. We could not find user information.',
-      username
+      username: profileUsername,
+      viewer
+    })
+  }
+})
+
+ROUTER.post('/', async (req, res) => {
+  const profileUsername = req.body.user?.trim() || req.body.username?.trim() || ''
+  const viewer = req.body.viewer?.trim() || ''
+  const university = req.body.university?.trim() || ''
+  const faculty = req.body.faculty?.trim() || ''
+  const school = req.body.school?.trim() || ''
+
+  if (!profileUsername) {
+    return res.redirect('/login')
+  }
+
+  try {
+    await connectToDatabase()
+    const user = await getUser(profileUsername)
+
+    if (!user) {
+      return res.redirect('/login')
+    }
+
+    const resolvedUsername = user.username || profileUsername
+
+    if (viewer !== resolvedUsername) {
+      return renderProfile(res, {
+        statusCode: 403,
+        error: 'You can only edit your own profile.',
+        ...buildProfileViewState(user, {
+          canEdit: false,
+          username: resolvedUsername,
+          viewer
+        })
+      })
+    }
+
+    const institutionValidation = await validateSelection({
+      faculty,
+      school,
+      university
+    })
+
+    if (!institutionValidation.isValid) {
+      return renderProfile(res, {
+        statusCode: institutionValidation.statusCode,
+        error: institutionValidation.error,
+        ...buildProfileViewState(user, {
+          canEdit: true,
+          faculty,
+          school,
+          university,
+          username: resolvedUsername,
+          viewer
+        })
+      })
+    }
+
+    await updateUserInstitutions(resolvedUsername, {
+      facultyId: faculty,
+      schoolId: school,
+      universityId: university
+    })
+
+    return renderProfile(res, buildProfileViewState(user, {
+      canEdit: true,
+      faculty,
+      school,
+      university,
+      username: resolvedUsername,
+      viewer
+    }))
+  } catch (error) {
+    return renderProfile(res, {
+      statusCode: 500,
+      error: 'Sorry. We could not update your institution information.',
+      username: profileUsername,
+      viewer,
+      university,
+      faculty,
+      school
     })
   }
 })

--- a/src/services/institution_validation.js
+++ b/src/services/institution_validation.js
@@ -1,0 +1,66 @@
+const {
+  getFaculty,
+  getSchool,
+  getUniversity,
+  isFacultyInUniversity,
+  isSchoolInFaculty
+} = require('../models/university_db')
+
+const createValidationFailure = function (error, statusCode = 400) {
+  return {
+    error,
+    isValid: false,
+    statusCode
+  }
+}
+
+/**
+ * Validates that the selected university, faculty, and school exist and match.
+ * @param {object} selection - Institution values supplied by a form.
+ * @param {string} [selection.university=''] - Selected university name.
+ * @param {string} [selection.faculty=''] - Selected faculty name.
+ * @param {string} [selection.school=''] - Selected school name.
+ * @returns {Promise<object>} Validation result containing status and matched institutions.
+ */
+const validateSelection = async function ({
+  university = '',
+  faculty = '',
+  school = ''
+} = {}) {
+  const matchedUniversity = await getUniversity(university)
+
+  if (!matchedUniversity) {
+    return createValidationFailure('Choose a university from the database list.')
+  }
+
+  const matchedFaculty = await getFaculty(faculty)
+
+  if (!matchedFaculty) {
+    return createValidationFailure('Choose a faculty from the database list.')
+  }
+
+  if (!(await isFacultyInUniversity(matchedFaculty, matchedUniversity))) {
+    return createValidationFailure('Choose a faculty that belongs to the selected university.')
+  }
+
+  const matchedSchool = await getSchool(school)
+
+  if (!matchedSchool) {
+    return createValidationFailure('Choose a school from the database list.')
+  }
+
+  if (!(await isSchoolInFaculty(matchedSchool, matchedFaculty))) {
+    return createValidationFailure('Choose a school that belongs to the selected faculty.')
+  }
+
+  return {
+    isValid: true,
+    matchedFaculty,
+    matchedSchool,
+    matchedUniversity
+  }
+}
+
+module.exports = {
+  validateSelection
+}

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -11,7 +11,7 @@
     <header>
       <h1>Hello <%= username %></h1>
     </header>
-    <a class="back_link" href="/user_profile?username=<%= encodeURIComponent(username) %>">User Profile</a>
+    <a class="back_link" href="/user_profile?user=<%= encodeURIComponent(username) %>&viewer=<%= encodeURIComponent(username) %>">User Profile</a>
   </main>
 </body>
 </html>

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -9,8 +9,9 @@
 <body class="page page_home">
   <main class="card card_wide text_center">
     <header>
-      <h1>Home Page</h1>
+      <h1>Hello <%= username %></h1>
     </header>
+    <a class="back_link" href="/user_profile?username=<%= encodeURIComponent(username) %>">User Profile</a>
   </main>
 </body>
 </html>

--- a/src/views/register.ejs
+++ b/src/views/register.ejs
@@ -58,19 +58,19 @@
           <div class="register_right_column">
             <label>
               University
-              <input id="university" type="search" name="university" value="<%= university %>" placeholder="..." autocomplete="off" list="university_options" aria-describedby="university_search_status" data-search-url="/register/universities" data-search-label="university" required>
+              <input id="university" type="search" name="university" value="<%= university %>" placeholder="..." autocomplete="off" list="university_options" aria-describedby="university_search_status" data-search-url="/institutions/universities" data-search-label="university" required>
               <datalist id="university_options"></datalist>
               <p id="university_search_status" class="search_status" aria-live="polite"></p>
             </label>
             <label>
               Faculty
-              <input id="faculty" type="search" name="faculty" value="<%= faculty %>" placeholder="..." autocomplete="off" list="faculty_options" aria-describedby="faculty_search_status" data-search-url="/register/faculties" data-search-label="faculty" data-search-parents="university" required>
+              <input id="faculty" type="search" name="faculty" value="<%= faculty %>" placeholder="..." autocomplete="off" list="faculty_options" aria-describedby="faculty_search_status" data-search-url="/institutions/faculties" data-search-label="faculty" data-search-parents="university" required>
               <datalist id="faculty_options"></datalist>
               <p id="faculty_search_status" class="search_status" aria-live="polite"></p>
             </label>
             <label>
               School
-              <input id="school" type="search" name="school" value="<%= school %>" placeholder="..." autocomplete="off" list="school_options" aria-describedby="school_search_status" data-search-url="/register/schools" data-search-label="school" data-search-parents="university,faculty" required>
+              <input id="school" type="search" name="school" value="<%= school %>" placeholder="..." autocomplete="off" list="school_options" aria-describedby="school_search_status" data-search-url="/institutions/schools" data-search-label="school" data-search-parents="university,faculty" required>
               <datalist id="school_options"></datalist>
               <p id="school_search_status" class="search_status" aria-live="polite"></p>
             </label>

--- a/src/views/register.ejs
+++ b/src/views/register.ejs
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title><%= title %></title>
   <link rel="stylesheet" href="/styles/main.css">
+  <script src="/scripts/search.js" defer></script>
 </head>
 <body class="page page_login">
-  <main class="card card_narrow">
+  <main class="card card_even_wider">
     <header>
       <h1>Register</h1>
       <p>Welcome to Let's Talk</p>
@@ -19,20 +20,62 @@
       <% } %>
 
       <form action="/register" method="post">
-        <label>
-          Email Address
-          <input type="text" name="emailAddress" value="<%= emailAddress %>" placeholder="1234567@students.wits.ac.za" required>
-        </label>
+        <div class="register_columns">
+          <div class="register_left_column">
+            <label>
+              Username
+              <input type="text" name="username" value="<%= username %>" placeholder="username" required>
+            </label>
+            <label>
+              Password
+              <input type="password" name="password" placeholder="password" required>
+            </label>
+            <label>
+              Email Address
+              <input type="text" name="emailAddress" value="<%= emailAddress %>" placeholder="1234567@students.wits.ac.za" required>
+            </label>
+            </div>
 
-        <label>
-          Username
-          <input type="text" name="username" value="<%= username %>" placeholder="username" required>
-        </label>
-
-        <label>
-          Password
-          <input type="password" name="password" placeholder="password" required>
-        </label>
+            <div class="register_middle_column">
+            <label>
+              First Name(s)
+              <input type="text" name="name" value="<%= name %>" placeholder="Stephen" required>
+            </label>
+            <label>
+              Last Name
+              <input type="text" name="surname" value="<%= surname %>" placeholder="Levitt" required>
+            </label>
+            <label>
+              Role
+                <select id="role" name="role" required>
+                  <option value="" disabled selected>Select one...</option>
+                  <option value="student">Student</option>
+                  <option value="lecturer">Lecturer</option>
+                </select>
+            </label>
+          </div>
+               
+          <div class="register_right_column">
+            <label>
+              University
+              <input id="university" type="search" name="university" value="<%= university %>" placeholder="..." autocomplete="off" list="university_options" aria-describedby="university_search_status" data-search-url="/register/universities" data-search-label="university" required>
+              <datalist id="university_options"></datalist>
+              <p id="university_search_status" class="search_status" aria-live="polite"></p>
+            </label>
+            <label>
+              Faculty
+              <input id="faculty" type="search" name="faculty" value="<%= faculty %>" placeholder="..." autocomplete="off" list="faculty_options" aria-describedby="faculty_search_status" data-search-url="/register/faculties" data-search-label="faculty" data-search-parents="university" required>
+              <datalist id="faculty_options"></datalist>
+              <p id="faculty_search_status" class="search_status" aria-live="polite"></p>
+            </label>
+            <label>
+              School
+              <input id="school" type="search" name="school" value="<%= school %>" placeholder="..." autocomplete="off" list="school_options" aria-describedby="school_search_status" data-search-url="/register/schools" data-search-label="school" data-search-parents="university,faculty" required>
+              <datalist id="school_options"></datalist>
+              <p id="school_search_status" class="search_status" aria-live="polite"></p>
+            </label>
+          </div>
+        </div>
 
         <button type="submit">Register</button>
       </form>

--- a/src/views/register.ejs
+++ b/src/views/register.ejs
@@ -24,7 +24,13 @@
           <div class="register_left_column">
             <label>
               Username
-              <input type="text" name="username" value="<%= username %>" placeholder="username" required>
+              <input
+                type="text"
+                name="username"
+                value="<%= username %>"
+                placeholder="username"
+                required
+              >
             </label>
             <label>
               Password
@@ -32,45 +38,101 @@
             </label>
             <label>
               Email Address
-              <input type="text" name="emailAddress" value="<%= emailAddress %>" placeholder="1234567@students.wits.ac.za" required>
+              <input
+                type="text"
+                name="emailAddress"
+                value="<%= emailAddress %>"
+                placeholder="1234567@students.wits.ac.za"
+                required
+              >
             </label>
-            </div>
+          </div>
 
-            <div class="register_middle_column">
+          <div class="register_middle_column">
             <label>
               First Name(s)
-              <input type="text" name="name" value="<%= name %>" placeholder="Stephen" required>
+              <input
+                type="text"
+                name="name"
+                value="<%= name %>"
+                placeholder="Stephen"
+                required
+              >
             </label>
             <label>
               Last Name
-              <input type="text" name="surname" value="<%= surname %>" placeholder="Levitt" required>
+              <input
+                type="text"
+                name="surname"
+                value="<%= surname %>"
+                placeholder="Levitt"
+                required
+              >
             </label>
             <label>
               Role
-                <select id="role" name="role" required>
-                  <option value="" disabled selected>Select one...</option>
-                  <option value="student">Student</option>
-                  <option value="lecturer">Lecturer</option>
-                </select>
+              <select id="role" name="role" required>
+                <option value="" disabled selected>Select one...</option>
+                <option value="student">Student</option>
+                <option value="lecturer">Lecturer</option>
+              </select>
             </label>
           </div>
-               
+
           <div class="register_right_column">
             <label>
               University
-              <input id="university" type="search" name="university" value="<%= university %>" placeholder="..." autocomplete="off" list="university_options" aria-describedby="university_search_status" data-search-url="/institutions/universities" data-search-label="university" required>
+              <input
+                id="university"
+                type="search"
+                name="university"
+                value="<%= university %>"
+                placeholder="..."
+                autocomplete="off"
+                list="university_options"
+                aria-describedby="university_search_status"
+                data-search-url="/institutions/universities"
+                data-search-label="university"
+                required
+              >
               <datalist id="university_options"></datalist>
               <p id="university_search_status" class="search_status" aria-live="polite"></p>
             </label>
             <label>
               Faculty
-              <input id="faculty" type="search" name="faculty" value="<%= faculty %>" placeholder="..." autocomplete="off" list="faculty_options" aria-describedby="faculty_search_status" data-search-url="/institutions/faculties" data-search-label="faculty" data-search-parents="university" required>
+              <input
+                id="faculty"
+                type="search"
+                name="faculty"
+                value="<%= faculty %>"
+                placeholder="..."
+                autocomplete="off"
+                list="faculty_options"
+                aria-describedby="faculty_search_status"
+                data-search-url="/institutions/faculties"
+                data-search-label="faculty"
+                data-search-parents="university"
+                required
+              >
               <datalist id="faculty_options"></datalist>
               <p id="faculty_search_status" class="search_status" aria-live="polite"></p>
             </label>
             <label>
               School
-              <input id="school" type="search" name="school" value="<%= school %>" placeholder="..." autocomplete="off" list="school_options" aria-describedby="school_search_status" data-search-url="/institutions/schools" data-search-label="school" data-search-parents="university,faculty" required>
+              <input
+                id="school"
+                type="search"
+                name="school"
+                value="<%= school %>"
+                placeholder="..."
+                autocomplete="off"
+                list="school_options"
+                aria-describedby="school_search_status"
+                data-search-url="/institutions/schools"
+                data-search-label="school"
+                data-search-parents="university,faculty"
+                required
+              >
               <datalist id="school_options"></datalist>
               <p id="school_search_status" class="search_status" aria-live="polite"></p>
             </label>

--- a/src/views/user_profile.ejs
+++ b/src/views/user_profile.ejs
@@ -50,21 +50,59 @@
 
           <label>
             University
-            <input id="profile_university" type="search" name="university" value="<%= university %>" placeholder="..." autocomplete="off" list="profile_university_options" aria-describedby="profile_university_search_status" data-search-url="/institutions/universities" data-search-label="university" required>
+            <input
+              id="profile_university"
+              type="search"
+              name="university"
+              value="<%= university %>"
+              placeholder="..."
+              autocomplete="off"
+              list="profile_university_options"
+              aria-describedby="profile_university_search_status"
+              data-search-url="/institutions/universities"
+              data-search-label="university"
+              required
+            >
             <datalist id="profile_university_options"></datalist>
             <p id="profile_university_search_status" class="search_status" aria-live="polite"></p>
           </label>
 
           <label>
             Faculty
-            <input id="profile_faculty" type="search" name="faculty" value="<%= faculty %>" placeholder="..." autocomplete="off" list="profile_faculty_options" aria-describedby="profile_faculty_search_status" data-search-url="/institutions/faculties" data-search-label="faculty" data-search-parents="university" required>
+            <input
+              id="profile_faculty"
+              type="search"
+              name="faculty"
+              value="<%= faculty %>"
+              placeholder="..."
+              autocomplete="off"
+              list="profile_faculty_options"
+              aria-describedby="profile_faculty_search_status"
+              data-search-url="/institutions/faculties"
+              data-search-label="faculty"
+              data-search-parents="university"
+              required
+            >
             <datalist id="profile_faculty_options"></datalist>
             <p id="profile_faculty_search_status" class="search_status" aria-live="polite"></p>
           </label>
 
           <label>
             School
-            <input id="profile_school" type="search" name="school" value="<%= school %>" placeholder="..." autocomplete="off" list="profile_school_options" aria-describedby="profile_school_search_status" data-search-url="/institutions/schools" data-search-label="school" data-search-parents="university,faculty" required>
+            <input
+              id="profile_school"
+              type="search"
+              name="school"
+              value="<%= school %>"
+              placeholder="..."
+              autocomplete="off"
+              list="profile_school_options"
+              aria-describedby="profile_school_search_status"
+              data-search-url="/institutions/schools"
+              data-search-label="school"
+              data-search-parents="university,faculty"
+              required
+            >
             <datalist id="profile_school_options"></datalist>
             <p id="profile_school_search_status" class="search_status" aria-live="polite"></p>
           </label>

--- a/src/views/user_profile.ejs
+++ b/src/views/user_profile.ejs
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><%= title %></title>
+  <link rel="stylesheet" href="/styles/main.css">
+</head>
+<body class="page page_home">
+  <main class="card card_even_wider text_center">
+    <header>
+      <h1>Hello <%= username %></h1>
+    </header>
+
+    <% if (error) { %>
+      <div class="error"><%= error %></div>
+    <% } %>
+
+    <section class="profile_details">
+      <div class="profile_column">
+        <div class="profile_detail">
+          <h2 class="profile_detail_label">Username</h2>
+          <p class="profile_detail_value"><%= username %></p>
+        </div>
+        <div class="profile_detail">
+          <h2 class="profile_detail_label">First Name(s)</h2>
+          <p class="profile_detail_value"><%= name %></p>
+        </div>
+        <div class="profile_detail">
+          <h2 class="profile_detail_label">Last Name</h2>
+          <p class="profile_detail_value"><%= surname %></p>
+        </div>
+        <div class="profile_detail">
+          <h2 class="profile_detail_label">Email Address</h2>
+          <p class="profile_detail_value"><%= emailAddress %></p>
+        </div>
+      </div>
+
+      <div class="profile_column">
+        <div class="profile_detail">
+          <h2 class="profile_detail_label">Role</h2>
+          <p class="profile_detail_value"><%= role %></p>
+        </div>
+        <div class="profile_detail">
+          <h2 class="profile_detail_label">University</h2>
+          <p class="profile_detail_value"><%= university %></p>
+        </div>
+        <div class="profile_detail">
+          <h2 class="profile_detail_label">Faculty</h2>
+          <p class="profile_detail_value"><%= faculty %></p>
+        </div>
+        <div class="profile_detail">
+          <h2 class="profile_detail_label">School</h2>
+          <p class="profile_detail_value"><%= school %></p>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/src/views/user_profile.ejs
+++ b/src/views/user_profile.ejs
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title><%= title %></title>
   <link rel="stylesheet" href="/styles/main.css">
+  <script src="/scripts/search.js" defer></script>
 </head>
 <body class="page page_home">
   <main class="card card_even_wider text_center">
@@ -41,18 +42,36 @@
           <h2 class="profile_detail_label">Role</h2>
           <p class="profile_detail_value"><%= role %></p>
         </div>
-        <div class="profile_detail">
-          <h2 class="profile_detail_label">University</h2>
-          <p class="profile_detail_value"><%= university %></p>
-        </div>
-        <div class="profile_detail">
-          <h2 class="profile_detail_label">Faculty</h2>
-          <p class="profile_detail_value"><%= faculty %></p>
-        </div>
-        <div class="profile_detail">
-          <h2 class="profile_detail_label">School</h2>
-          <p class="profile_detail_value"><%= school %></p>
-        </div>
+
+        <% if (canEdit) { %>
+        <form class="profile_update_form" action="/user_profile?user=<%= encodeURIComponent(username) %>&viewer=<%= encodeURIComponent(viewer) %>" method="post">
+          <input type="hidden" name="user" value="<%= username %>">
+          <input type="hidden" name="viewer" value="<%= viewer %>">
+
+          <label>
+            University
+            <input id="profile_university" type="search" name="university" value="<%= university %>" placeholder="..." autocomplete="off" list="profile_university_options" aria-describedby="profile_university_search_status" data-search-url="/institutions/universities" data-search-label="university" required>
+            <datalist id="profile_university_options"></datalist>
+            <p id="profile_university_search_status" class="search_status" aria-live="polite"></p>
+          </label>
+
+          <label>
+            Faculty
+            <input id="profile_faculty" type="search" name="faculty" value="<%= faculty %>" placeholder="..." autocomplete="off" list="profile_faculty_options" aria-describedby="profile_faculty_search_status" data-search-url="/institutions/faculties" data-search-label="faculty" data-search-parents="university" required>
+            <datalist id="profile_faculty_options"></datalist>
+            <p id="profile_faculty_search_status" class="search_status" aria-live="polite"></p>
+          </label>
+
+          <label>
+            School
+            <input id="profile_school" type="search" name="school" value="<%= school %>" placeholder="..." autocomplete="off" list="profile_school_options" aria-describedby="profile_school_search_status" data-search-url="/institutions/schools" data-search-label="school" data-search-parents="university,faculty" required>
+            <datalist id="profile_school_options"></datalist>
+            <p id="profile_school_search_status" class="search_status" aria-live="polite"></p>
+          </label>
+
+          <button type="submit">Update Institution</button>
+        </form>
+        <% } %>
       </div>
     </section>
   </main>

--- a/tests/models/atlas.test.js
+++ b/tests/models/atlas.test.js
@@ -28,16 +28,16 @@ const EXPECTED_UNIVERSITY = {
 const EXPECTED_FACULTY = {
   _id: '69e7d63e5db99de0cf001bf2',
   name: 'Engineering and the Built Environment',
-  universityID: EXPECTED_UNIVERSITY._id,
+  universityId: EXPECTED_UNIVERSITY._id,
   universityName: EXPECTED_UNIVERSITY.name
 }
 
 const EXPECTED_SCHOOL = {
   _id: '69e7d9025db99de0cf001bfe',
-  facultyID: EXPECTED_FACULTY._id,
+  facultyId: EXPECTED_FACULTY._id,
   facultyName: EXPECTED_FACULTY.name,
   name: 'Electrical and Information Engineering',
-  universityID: EXPECTED_UNIVERSITY._id,
+  universityId: EXPECTED_UNIVERSITY._id,
   universityName: EXPECTED_UNIVERSITY.name
 }
 
@@ -131,7 +131,7 @@ describe('MongoDB Atlas institution lookups', () => {
       universityName: EXPECTED_FACULTY.universityName
     })
     expect(faculty._id.toString()).toBe(EXPECTED_FACULTY._id)
-    expect(faculty.universityID.toString()).toBe(EXPECTED_FACULTY.universityID)
+    expect(faculty.universityId.toString()).toBe(EXPECTED_FACULTY.universityId)
   })
 
   RUN_DB_TEST('Returns the expected school by id', async () => {
@@ -144,8 +144,8 @@ describe('MongoDB Atlas institution lookups', () => {
       universityName: EXPECTED_SCHOOL.universityName
     })
     expect(school._id.toString()).toBe(EXPECTED_SCHOOL._id)
-    expect(school.facultyID.toString()).toBe(EXPECTED_SCHOOL.facultyID)
-    expect(school.universityID.toString()).toBe(EXPECTED_SCHOOL.universityID)
+    expect(school.facultyId.toString()).toBe(EXPECTED_SCHOOL.facultyId)
+    expect(school.universityId.toString()).toBe(EXPECTED_SCHOOL.universityId)
   })
 
   RUN_DB_TEST('Confirms the faculty belongs to the university', async () => {

--- a/tests/models/atlas.test.js
+++ b/tests/models/atlas.test.js
@@ -8,6 +8,9 @@ const {
   getFaculty,
   getSchool,
   getUniversity,
+  searchFaculties,
+  searchSchools,
+  searchUniversities,
   isFacultyInUniversity,
   isSchoolInFaculty
 } = require('../../src/models/university_db')
@@ -74,6 +77,49 @@ describe('MongoDB Atlas institution lookups', () => {
       name: EXPECTED_UNIVERSITY.name
     })
     expect(university._id.toString()).toBe(EXPECTED_UNIVERSITY._id)
+  })
+
+  RUN_DB_TEST('Returns matching universities for a partial query', async () => {
+    const universities = await searchUniversities('wit', 5)
+
+    expect(universities).toEqual(
+      expect.arrayContaining([
+        {
+          name: EXPECTED_UNIVERSITY.name
+        }
+      ])
+    )
+  })
+
+  RUN_DB_TEST('Returns matching faculties for a partial query within a university', async () => {
+    const faculties = await searchFaculties('eng', {
+      limit: 5,
+      university: EXPECTED_UNIVERSITY.name
+    })
+
+    expect(faculties).toEqual(
+      expect.arrayContaining([
+        {
+          name: EXPECTED_FACULTY.name
+        }
+      ])
+    )
+  })
+
+  RUN_DB_TEST('Returns matching schools for a partial query within a faculty', async () => {
+    const schools = await searchSchools('elect', {
+      faculty: EXPECTED_FACULTY.name,
+      limit: 5,
+      university: EXPECTED_UNIVERSITY.name
+    })
+
+    expect(schools).toEqual(
+      expect.arrayContaining([
+        {
+          name: EXPECTED_SCHOOL.name
+        }
+      ])
+    )
   })
 
   RUN_DB_TEST('Returns the expected faculty by id', async () => {

--- a/tests/models/university_db.test.js
+++ b/tests/models/university_db.test.js
@@ -9,6 +9,9 @@ const {
   getFaculty,
   getSchool,
   getUniversity,
+  searchFaculties,
+  searchSchools,
+  searchUniversities,
   isFacultyInUniversity,
   isSchoolInFaculty
 } = require('../../src/models/university_db')
@@ -18,9 +21,9 @@ describe('institution relationship lookups', () => {
 
   beforeEach(() => {
     collections = {
-      Faculty: { findOne: jest.fn() },
-      School: { findOne: jest.fn() },
-      University: { findOne: jest.fn() }
+      Faculty: { find: jest.fn(), findOne: jest.fn() },
+      School: { find: jest.fn(), findOne: jest.fn() },
+      University: { find: jest.fn(), findOne: jest.fn() }
     }
 
     getCollection.mockImplementation((name) => collections[name])
@@ -51,6 +54,134 @@ describe('institution relationship lookups', () => {
 
     await expect(getFaculty(facultyId.toHexString())).resolves.toEqual(faculty)
     expect(collections.Faculty.findOne).toHaveBeenCalledWith({ _id: facultyId })
+  })
+
+  test('searchUniversities returns matching universities for a query', async () => {
+    const universityCursor = {
+      limit: jest.fn(),
+      sort: jest.fn(),
+      toArray: jest.fn()
+    }
+
+    universityCursor.sort.mockReturnValue(universityCursor)
+    universityCursor.limit.mockReturnValue(universityCursor)
+    universityCursor.toArray.mockResolvedValue([
+      {
+        name: 'University of the Witwatersrand'
+      }
+    ])
+
+    collections.University.find.mockReturnValue(universityCursor)
+
+    await expect(searchUniversities('wit', 5)).resolves.toEqual([
+      {
+        name: 'University of the Witwatersrand'
+      }
+    ])
+    expect(collections.University.find).toHaveBeenCalledWith(
+      {
+        name: {
+          $options: 'i',
+          $regex: 'wit'
+        }
+      },
+      {
+        projection: {
+          _id: 0,
+          name: 1
+        }
+      }
+    )
+    expect(universityCursor.sort).toHaveBeenCalledWith({ name: 1 })
+    expect(universityCursor.limit).toHaveBeenCalledWith(5)
+  })
+
+  test('searchFaculties filters faculties by university name', async () => {
+    const facultyCursor = {
+      limit: jest.fn(),
+      sort: jest.fn(),
+      toArray: jest.fn()
+    }
+
+    facultyCursor.sort.mockReturnValue(facultyCursor)
+    facultyCursor.limit.mockReturnValue(facultyCursor)
+    facultyCursor.toArray.mockResolvedValue([
+      {
+        name: 'Engineering and the Built Environment'
+      }
+    ])
+
+    collections.Faculty.find.mockReturnValue(facultyCursor)
+
+    await expect(searchFaculties('eng', {
+      limit: 4,
+      university: 'University of the Witwatersrand'
+    })).resolves.toEqual([
+      {
+        name: 'Engineering and the Built Environment'
+      }
+    ])
+    expect(collections.Faculty.find).toHaveBeenCalledWith(
+      {
+        name: {
+          $options: 'i',
+          $regex: 'eng'
+        },
+        universityName: 'University of the Witwatersrand'
+      },
+      {
+        projection: {
+          _id: 0,
+          name: 1
+        }
+      }
+    )
+    expect(facultyCursor.limit).toHaveBeenCalledWith(4)
+  })
+
+  test('searchSchools filters schools by university and faculty names', async () => {
+    const schoolCursor = {
+      limit: jest.fn(),
+      sort: jest.fn(),
+      toArray: jest.fn()
+    }
+
+    schoolCursor.sort.mockReturnValue(schoolCursor)
+    schoolCursor.limit.mockReturnValue(schoolCursor)
+    schoolCursor.toArray.mockResolvedValue([
+      {
+        name: 'Electrical and Information Engineering'
+      }
+    ])
+
+    collections.School.find.mockReturnValue(schoolCursor)
+
+    await expect(searchSchools('elect', {
+      faculty: 'Engineering and the Built Environment',
+      limit: 3,
+      university: 'University of the Witwatersrand'
+    })).resolves.toEqual([
+      {
+        name: 'Electrical and Information Engineering'
+      }
+    ])
+    expect(collections.School.find).toHaveBeenCalledWith(
+      {
+        facultyName: 'Engineering and the Built Environment',
+        name: {
+          $options: 'i',
+          $regex: 'elect'
+        },
+        universityName: 'University of the Witwatersrand'
+      },
+      {
+        projection: {
+          _id: 0,
+          name: 1
+        }
+      }
+    )
+    expect(schoolCursor.limit).toHaveBeenCalledWith(3)
   })
 
   test('getSchool finds a school by id', async () => {

--- a/tests/models/university_db.test.js
+++ b/tests/models/university_db.test.js
@@ -47,7 +47,7 @@ describe('institution relationship lookups', () => {
     const faculty = {
       _id: facultyId,
       name: 'Engineering and the Built Environment',
-      universityID: new ObjectId()
+      universityId: new ObjectId()
     }
 
     collections.Faculty.findOne.mockResolvedValue(faculty)
@@ -188,9 +188,9 @@ describe('institution relationship lookups', () => {
     const schoolId = new ObjectId()
     const school = {
       _id: schoolId,
-      facultyID: new ObjectId(),
+      facultyId: new ObjectId(),
       name: 'Electrical and Information Engineering',
-      universityID: new ObjectId()
+      universityId: new ObjectId()
     }
 
     collections.School.findOne.mockResolvedValue(school)
@@ -205,7 +205,7 @@ describe('institution relationship lookups', () => {
     const faculty = {
       _id: facultyId,
       name: 'Engineering and the Built Environment',
-      universityID: universityId
+      universityId
     }
     const university = {
       _id: universityId,
@@ -220,14 +220,33 @@ describe('institution relationship lookups', () => {
     expect(collections.University.findOne).toHaveBeenCalledWith({ _id: universityId })
   })
 
+  test('isFacultyInUniversity supports camelCase universityId fields', async () => {
+    const facultyId = new ObjectId()
+    const universityId = new ObjectId()
+    const faculty = {
+      _id: facultyId,
+      name: 'Engineering and the Built Environment',
+      universityId
+    }
+    const university = {
+      _id: universityId,
+      name: 'University of the Witwatersrand'
+    }
+
+    collections.Faculty.findOne.mockResolvedValue(faculty)
+    collections.University.findOne.mockResolvedValue(university)
+
+    await expect(isFacultyInUniversity(facultyId.toHexString(), universityId.toHexString())).resolves.toBe(true)
+  })
+
   test('isSchoolInFaculty returns true when the school belongs to the faculty', async () => {
     const facultyId = new ObjectId()
     const schoolId = new ObjectId()
     const school = {
       _id: schoolId,
-      facultyID: facultyId,
+      facultyId,
       name: 'Electrical and Information Engineering',
-      universityID: new ObjectId()
+      universityId: new ObjectId()
     }
     const faculty = {
       _id: facultyId,
@@ -240,5 +259,25 @@ describe('institution relationship lookups', () => {
     await expect(isSchoolInFaculty(schoolId.toHexString(), facultyId.toHexString())).resolves.toBe(true)
     expect(collections.School.findOne).toHaveBeenCalledWith({ _id: schoolId })
     expect(collections.Faculty.findOne).toHaveBeenCalledWith({ _id: facultyId })
+  })
+
+  test('isSchoolInFaculty supports camelCase facultyId fields', async () => {
+    const facultyId = new ObjectId()
+    const schoolId = new ObjectId()
+    const school = {
+      _id: schoolId,
+      facultyId,
+      name: 'Electrical and Information Engineering',
+      universityId: new ObjectId()
+    }
+    const faculty = {
+      _id: facultyId,
+      name: 'Engineering and the Built Environment'
+    }
+
+    collections.School.findOne.mockResolvedValue(school)
+    collections.Faculty.findOne.mockResolvedValue(faculty)
+
+    await expect(isSchoolInFaculty(schoolId.toHexString(), facultyId.toHexString())).resolves.toBe(true)
   })
 })

--- a/tests/routes/institution_search.test.js
+++ b/tests/routes/institution_search.test.js
@@ -1,0 +1,216 @@
+jest.mock('../../src/models/db', () => ({
+  closeDatabaseConnection: jest.fn(),
+  connectToDatabase: jest.fn().mockResolvedValue(undefined),
+  DATABASE_NAME: 'LetsTalk',
+  getCollection: jest.fn(),
+  getDb: jest.fn(),
+  getMongoUri: jest.fn()
+}))
+
+jest.mock('../../src/models/user_db', () => ({
+  addUser: jest.fn(),
+  deleteUser: jest.fn(),
+  getUser: jest.fn()
+}))
+
+jest.mock('../../src/models/university_db', () => ({
+  getFaculty: jest.fn(),
+  getSchool: jest.fn(),
+  getUniversity: jest.fn(),
+  isFacultyInUniversity: jest.fn(),
+  isSchoolInFaculty: jest.fn(),
+  searchFaculties: jest.fn(),
+  searchSchools: jest.fn(),
+  searchUniversities: jest.fn()
+}))
+
+const http = require('node:http')
+
+const { connectToDatabase } = require('../../src/models/db')
+const {
+  searchFaculties,
+  searchSchools,
+  searchUniversities
+} = require('../../src/models/university_db')
+const app = require('../../src/app')
+
+describe('institution search route', () => {
+  let server
+  let baseUrl
+
+  beforeAll(async () => {
+    server = http.createServer(app)
+    await new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        baseUrl = `http://127.0.0.1:${server.address().port}`
+        resolve()
+      })
+    })
+  })
+
+  afterAll(async () => {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve()
+      })
+    })
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    connectToDatabase.mockResolvedValue(undefined)
+    searchFaculties.mockResolvedValue([
+      { name: 'Engineering and the Built Environment' }
+    ])
+    searchSchools.mockResolvedValue([
+      { name: 'Electrical and Information Engineering' }
+    ])
+    searchUniversities.mockResolvedValue([
+      { name: 'University of the Witwatersrand' }
+    ])
+  })
+
+  test('Returns matching universities for the shared search endpoint', async () => {
+    const response = await fetch(`${baseUrl}/institutions/universities?query=wit`, {
+      headers: {
+        accept: 'application/json'
+      }
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      results: ['University of the Witwatersrand']
+    })
+    expect(connectToDatabase).toHaveBeenCalledTimes(1)
+    expect(searchUniversities).toHaveBeenCalledWith('wit', 8)
+  })
+
+  test('Returns no universities when the shared search query is blank', async () => {
+    const response = await fetch(`${baseUrl}/institutions/universities?query=%20%20`, {
+      headers: {
+        accept: 'application/json'
+      }
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ results: [] })
+    expect(connectToDatabase).not.toHaveBeenCalled()
+    expect(searchUniversities).not.toHaveBeenCalled()
+  })
+
+  test('Returns a server error when university search fails', async () => {
+    searchUniversities.mockRejectedValue(new Error('search failed'))
+
+    const response = await fetch(`${baseUrl}/institutions/universities?query=wit`, {
+      headers: {
+        accept: 'application/json'
+      }
+    })
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({
+      error: 'Sorry. We can not search universities right now.',
+      results: []
+    })
+  })
+
+  test('Returns matching faculties for the shared search endpoint', async () => {
+    const response = await fetch(`${baseUrl}/institutions/faculties?query=eng&university=University%20of%20the%20Witwatersrand`, {
+      headers: {
+        accept: 'application/json'
+      }
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      results: ['Engineering and the Built Environment']
+    })
+    expect(connectToDatabase).toHaveBeenCalledTimes(1)
+    expect(searchFaculties).toHaveBeenCalledWith('eng', {
+      limit: 8,
+      university: 'University of the Witwatersrand'
+    })
+  })
+
+  test('Returns no faculties when the shared search query is blank', async () => {
+    const response = await fetch(`${baseUrl}/institutions/faculties?query=%20%20&university=University%20of%20the%20Witwatersrand`, {
+      headers: {
+        accept: 'application/json'
+      }
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ results: [] })
+    expect(connectToDatabase).not.toHaveBeenCalled()
+    expect(searchFaculties).not.toHaveBeenCalled()
+  })
+
+  test('Returns a server error when faculty search fails', async () => {
+    searchFaculties.mockRejectedValue(new Error('search failed'))
+
+    const response = await fetch(`${baseUrl}/institutions/faculties?query=eng&university=University%20of%20the%20Witwatersrand`, {
+      headers: {
+        accept: 'application/json'
+      }
+    })
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({
+      error: 'Sorry. We can not search faculties right now.',
+      results: []
+    })
+  })
+
+  test('Returns matching schools for the shared search endpoint', async () => {
+    const response = await fetch(`${baseUrl}/institutions/schools?query=elect&university=University%20of%20the%20Witwatersrand&faculty=Engineering%20and%20the%20Built%20Environment`, {
+      headers: {
+        accept: 'application/json'
+      }
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      results: ['Electrical and Information Engineering']
+    })
+    expect(connectToDatabase).toHaveBeenCalledTimes(1)
+    expect(searchSchools).toHaveBeenCalledWith('elect', {
+      faculty: 'Engineering and the Built Environment',
+      limit: 8,
+      university: 'University of the Witwatersrand'
+    })
+  })
+
+  test('Returns no schools when the shared search query is blank', async () => {
+    const response = await fetch(`${baseUrl}/institutions/schools?query=%20%20&university=University%20of%20the%20Witwatersrand&faculty=Engineering%20and%20the%20Built%20Environment`, {
+      headers: {
+        accept: 'application/json'
+      }
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ results: [] })
+    expect(connectToDatabase).not.toHaveBeenCalled()
+    expect(searchSchools).not.toHaveBeenCalled()
+  })
+
+  test('Returns a server error when school search fails', async () => {
+    searchSchools.mockRejectedValue(new Error('search failed'))
+
+    const response = await fetch(`${baseUrl}/institutions/schools?query=elect&university=University%20of%20the%20Witwatersrand&faculty=Engineering%20and%20the%20Built%20Environment`, {
+      headers: {
+        accept: 'application/json'
+      }
+    })
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({
+      error: 'Sorry. We could not search schools right now.',
+      results: []
+    })
+  })
+})

--- a/tests/routes/login.test.js
+++ b/tests/routes/login.test.js
@@ -79,9 +79,19 @@ describe('login route', () => {
     })
 
     expect(response.status).toBe(302)
-    expect(response.headers.get('location')).toBe('/home')
+    expect(response.headers.get('location')).toBe('/home?username=morris')
     expect(connectToDatabase).toHaveBeenCalledTimes(1)
     expect(getUser).toHaveBeenCalledWith('morris')
+  })
+
+  test('Renders the Login page for GET requests', async () => {
+    const response = await fetch(`${baseUrl}/login`)
+
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(connectToDatabase).not.toHaveBeenCalled()
+    expect(body).toContain('<title>Log In</title>')
   })
 
   test('Re-renders the Login page when required fields are missing', async () => {
@@ -140,5 +150,25 @@ describe('login route', () => {
 
     expect(response.status).toBe(401)
     expect(body).toContain('Password is incorrect.')
+  })
+
+  test('Re-renders the Login page when the database request fails', async () => {
+    connectToDatabase.mockRejectedValue(new Error('database unavailable'))
+
+    const response = await fetch(`${baseUrl}/login`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: encodeForm({
+        password: 'welovesd3',
+        username: 'morris'
+      })
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(500)
+    expect(body).toContain('Sorry. We could not log you in. Try again later.')
   })
 })

--- a/tests/routes/register.test.js
+++ b/tests/routes/register.test.js
@@ -13,9 +13,30 @@ jest.mock('../../src/models/user_db', () => ({
   getUser: jest.fn()
 }))
 
+jest.mock('../../src/models/university_db', () => ({
+  getFaculty: jest.fn(),
+  getSchool: jest.fn(),
+  getUniversity: jest.fn(),
+  isFacultyInUniversity: jest.fn(),
+  isSchoolInFaculty: jest.fn(),
+  searchFaculties: jest.fn(),
+  searchSchools: jest.fn(),
+  searchUniversities: jest.fn()
+}))
+
 const http = require('node:http')
 
 const { connectToDatabase } = require('../../src/models/db')
+const {
+  getFaculty,
+  getSchool,
+  getUniversity,
+  isFacultyInUniversity,
+  isSchoolInFaculty,
+  searchFaculties,
+  searchSchools,
+  searchUniversities
+} = require('../../src/models/university_db')
 const { addUser } = require('../../src/models/user_db')
 const app = require('../../src/app')
 
@@ -59,6 +80,20 @@ describe('register route', () => {
     jest.clearAllMocks()
     connectToDatabase.mockResolvedValue(undefined)
     addUser.mockResolvedValue({ acknowledged: true, insertedId: 'new-user-id' })
+    getFaculty.mockResolvedValue({ name: 'Engineering and the Built Environment' })
+    getSchool.mockResolvedValue({ name: 'Electrical and Information Engineering' })
+    getUniversity.mockResolvedValue({ name: 'University of the Witwatersrand' })
+    isFacultyInUniversity.mockResolvedValue(true)
+    isSchoolInFaculty.mockResolvedValue(true)
+    searchFaculties.mockResolvedValue([
+      { name: 'Engineering and the Built Environment' }
+    ])
+    searchSchools.mockResolvedValue([
+      { name: 'Electrical and Information Engineering' }
+    ])
+    searchUniversities.mockResolvedValue([
+      { name: 'University of the Witwatersrand' }
+    ])
   })
 
   test('Creates a user from the Register form and redirects to login page', async () => {
@@ -69,7 +104,13 @@ describe('register route', () => {
       },
       body: encodeForm({
         emailAddress: 'newUser@example.com',
+        faculty: 'Engineering and the Built Environment',
+        name: 'Morris',
         password: 'welovesd3',
+        role: 'student',
+        school: 'Electrical and Information Engineering',
+        surname: 'Wits',
+        university: 'University of the Witwatersrand',
         username: 'morris'
       }),
       redirect: 'manual'
@@ -81,18 +122,163 @@ describe('register route', () => {
     expect(addUser).toHaveBeenCalledTimes(1)
     expect(addUser).toHaveBeenCalledWith(expect.objectContaining({
       email: 'newuser@example.com',
-      facultyId: 'unassigned',
-      firstName: 'Pending',
-      lastName: 'Pending',
+      facultyId: 'Engineering and the Built Environment',
+      firstName: 'Morris',
+      lastName: 'Wits',
       role: 'student',
-      schoolId: 'unassigned',
-      universityId: 'unassigned',
+      schoolId: 'Electrical and Information Engineering',
+      universityId: 'University of the Witwatersrand',
       username: 'morris'
     }))
+    expect(getFaculty).toHaveBeenCalledWith('Engineering and the Built Environment')
+    expect(getSchool).toHaveBeenCalledWith('Electrical and Information Engineering')
+    expect(getUniversity).toHaveBeenCalledWith('University of the Witwatersrand')
+    expect(isFacultyInUniversity).toHaveBeenCalled()
+    expect(isSchoolInFaculty).toHaveBeenCalled()
 
     const insertedUser = addUser.mock.calls[0][0]
     expect(insertedUser.passwordHash).toContain(':')
     expect(insertedUser.passwordHash).not.toBe('welovesd3')
+  })
+
+  test('Re-renders the Register page when the university is not from the database list', async () => {
+    getUniversity.mockResolvedValue(null)
+
+    const response = await fetch(`${baseUrl}/register`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: encodeForm({
+        emailAddress: 'newUser@example.com',
+        faculty: 'Engineering and the Built Environment',
+        name: 'Morris',
+        password: 'welovesd3',
+        role: 'student',
+        school: 'Electrical and Information Engineering',
+        surname: 'Wits',
+        university: 'Unknown University',
+        username: 'morris'
+      })
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(400)
+    expect(addUser).not.toHaveBeenCalled()
+    expect(body).toContain('Choose a university from the database list.')
+  })
+
+  test('Re-renders the Register page when the faculty is not from the database list', async () => {
+    getFaculty.mockResolvedValue(null)
+
+    const response = await fetch(`${baseUrl}/register`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: encodeForm({
+        emailAddress: 'newUser@example.com',
+        faculty: 'Unknown Faculty',
+        name: 'Morris',
+        password: 'welovesd3',
+        role: 'student',
+        school: 'Electrical and Information Engineering',
+        surname: 'Wits',
+        university: 'University of the Witwatersrand',
+        username: 'morris'
+      })
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(400)
+    expect(addUser).not.toHaveBeenCalled()
+    expect(body).toContain('Choose a faculty from the database list.')
+  })
+
+  test('Re-renders the Register page when the faculty does not belong to the selected university', async () => {
+    isFacultyInUniversity.mockResolvedValue(false)
+
+    const response = await fetch(`${baseUrl}/register`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: encodeForm({
+        emailAddress: 'newUser@example.com',
+        faculty: 'Engineering and the Built Environment',
+        name: 'Morris',
+        password: 'welovesd3',
+        role: 'student',
+        school: 'Electrical and Information Engineering',
+        surname: 'Wits',
+        university: 'University of the Witwatersrand',
+        username: 'morris'
+      })
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(400)
+    expect(addUser).not.toHaveBeenCalled()
+    expect(body).toContain('Choose a faculty that belongs to the selected university.')
+  })
+
+  test('Re-renders the Register page when the school is not from the database list', async () => {
+    getSchool.mockResolvedValue(null)
+
+    const response = await fetch(`${baseUrl}/register`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: encodeForm({
+        emailAddress: 'newUser@example.com',
+        faculty: 'Engineering and the Built Environment',
+        name: 'Morris',
+        password: 'welovesd3',
+        role: 'student',
+        school: 'Unknown School',
+        surname: 'Wits',
+        university: 'University of the Witwatersrand',
+        username: 'morris'
+      })
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(400)
+    expect(addUser).not.toHaveBeenCalled()
+    expect(body).toContain('Choose a school from the database list.')
+  })
+
+  test('Re-renders the Register page when the school does not belong to the selected faculty', async () => {
+    isSchoolInFaculty.mockResolvedValue(false)
+
+    const response = await fetch(`${baseUrl}/register`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: encodeForm({
+        emailAddress: 'newUser@example.com',
+        faculty: 'Engineering and the Built Environment',
+        name: 'Morris',
+        password: 'welovesd3',
+        role: 'student',
+        school: 'Electrical and Information Engineering',
+        surname: 'Wits',
+        university: 'University of the Witwatersrand',
+        username: 'morris'
+      })
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(400)
+    expect(addUser).not.toHaveBeenCalled()
+    expect(body).toContain('Choose a school that belongs to the selected faculty.')
   })
 
   test('Re-renders the Register page when required fields are missing', async () => {
@@ -103,7 +289,13 @@ describe('register route', () => {
       },
       body: encodeForm({
         emailAddress: '',
+        faculty: '',
+        name: '',
         password: '',
+        role: '',
+        school: '',
+        surname: '',
+        university: '',
         username: ''
       })
     })
@@ -113,7 +305,7 @@ describe('register route', () => {
     expect(response.status).toBe(400)
     expect(connectToDatabase).not.toHaveBeenCalled()
     expect(addUser).not.toHaveBeenCalled()
-    expect(body).toContain('Username, Email and Password are required.')
+    expect(body).toContain('Username, password, first/last names and institution credentials are required.')
   })
 
   test('Re-renders the Register page when the email address format is invalid', async () => {
@@ -124,7 +316,13 @@ describe('register route', () => {
       },
       body: encodeForm({
         emailAddress: 'not-an-email',
+        faculty: 'Engineering and the Built Environment',
+        name: 'Morris',
         password: 'welovesd3',
+        role: 'student',
+        school: 'Electrical and Information Engineering',
+        surname: 'Wits',
+        university: 'University of the Witwatersrand',
         username: 'morris'
       })
     })
@@ -147,7 +345,13 @@ describe('register route', () => {
       },
       body: encodeForm({
         emailAddress: 'newUser@example.com',
+        faculty: 'Engineering and the Built Environment',
+        name: 'Morris',
         password: 'welovesd3',
+        role: 'student',
+        school: 'Electrical and Information Engineering',
+        surname: 'Wits',
+        university: 'University of the Witwatersrand',
         username: 'morris'
       })
     })

--- a/tests/routes/user_profile.test.js
+++ b/tests/routes/user_profile.test.js
@@ -102,7 +102,7 @@ describe('user profile route', () => {
     expect(body).toContain('Update Institution')
     expect(body).toContain('Morris')
     expect(body).toContain('Wits')
-    expect(body).toContain('morris@example.com')
+    expect(body).toContain('sd3lovers@example.com')
     expect(body).toContain('University of the Witwatersrand')
     expect(body).toContain('Engineering and the Built Environment')
     expect(body).toContain('Electrical and Information Engineering')

--- a/tests/routes/user_profile.test.js
+++ b/tests/routes/user_profile.test.js
@@ -1,0 +1,230 @@
+jest.mock('../../src/models/db', () => ({
+  closeDatabaseConnection: jest.fn(),
+  connectToDatabase: jest.fn().mockResolvedValue(undefined),
+  DATABASE_NAME: 'LetsTalk',
+  getCollection: jest.fn(),
+  getDb: jest.fn(),
+  getMongoUri: jest.fn()
+}))
+
+jest.mock('../../src/models/user_db', () => ({
+  addUser: jest.fn(),
+  deleteUser: jest.fn(),
+  getUser: jest.fn(),
+  updateUserInstitutions: jest.fn()
+}))
+
+jest.mock('../../src/models/university_db', () => ({
+  getFaculty: jest.fn(),
+  getSchool: jest.fn(),
+  getUniversity: jest.fn(),
+  isFacultyInUniversity: jest.fn(),
+  isSchoolInFaculty: jest.fn(),
+  searchFaculties: jest.fn(),
+  searchSchools: jest.fn(),
+  searchUniversities: jest.fn()
+}))
+
+const http = require('node:http')
+
+const { connectToDatabase } = require('../../src/models/db')
+const { getUser, updateUserInstitutions } = require('../../src/models/user_db')
+const {
+  getFaculty,
+  getSchool,
+  getUniversity,
+  isFacultyInUniversity,
+  isSchoolInFaculty
+} = require('../../src/models/university_db')
+const app = require('../../src/app')
+
+const encodeForm = function (fields) {
+  return new URLSearchParams(fields).toString()
+}
+
+describe('user profile route', () => {
+  let server
+  let baseUrl
+
+  beforeAll(async () => {
+    server = http.createServer(app)
+    await new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        baseUrl = `http://127.0.0.1:${server.address().port}`
+        resolve()
+      })
+    })
+  })
+
+  afterAll(async () => {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve()
+      })
+    })
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    connectToDatabase.mockResolvedValue(undefined)
+    updateUserInstitutions.mockResolvedValue({ acknowledged: true, modifiedCount: 1 })
+    getUser.mockResolvedValue({
+      email: 'sd3lovers@example.com',
+      facultyId: 'Engineering and the Built Environment',
+      firstName: 'Morris',
+      lastName: 'Wits',
+      role: 'student',
+      schoolId: 'Electrical and Information Engineering',
+      universityId: 'University of the Witwatersrand',
+      username: 'morris'
+    })
+    getFaculty.mockResolvedValue({ name: 'Engineering and the Built Environment' })
+    getSchool.mockResolvedValue({ name: 'Electrical and Information Engineering' })
+    getUniversity.mockResolvedValue({ name: 'University of the Witwatersrand' })
+    isFacultyInUniversity.mockResolvedValue(true)
+    isSchoolInFaculty.mockResolvedValue(true)
+  })
+
+  test('Renders the owner profile with the edit form', async () => {
+    const response = await fetch(`${baseUrl}/user_profile?user=morris&viewer=morris`)
+
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(connectToDatabase).toHaveBeenCalledTimes(1)
+    expect(getUser).toHaveBeenCalledWith('morris')
+    expect(body).toContain('Hello morris')
+    expect(body).toContain('Update Institution')
+    expect(body).toContain('Morris')
+    expect(body).toContain('Wits')
+    expect(body).toContain('morris@example.com')
+    expect(body).toContain('University of the Witwatersrand')
+    expect(body).toContain('Engineering and the Built Environment')
+    expect(body).toContain('Electrical and Information Engineering')
+  })
+
+  test('Renders another user profile without the edit form for the viewer', async () => {
+    getUser.mockResolvedValue({
+      email: 'alice@example.com',
+      facultyId: 'Faculty of Science',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      role: 'student',
+      schoolId: 'School of Chemistry',
+      universityId: 'University of Cape Town',
+      username: 'alice'
+    })
+
+    const response = await fetch(`${baseUrl}/user_profile?user=alice&viewer=morris`)
+
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(getUser).toHaveBeenCalledWith('alice')
+    expect(body).toContain('Hello alice')
+    expect(body).not.toContain('Update Institution')
+    expect(body).toContain('alice@example.com')
+  })
+
+  test('Redirects to login when the user does not exist', async () => {
+    getUser.mockResolvedValue(null)
+
+    const response = await fetch(`${baseUrl}/user_profile?user=missing&viewer=morris`, {
+      redirect: 'manual'
+    })
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('/login')
+  })
+
+  test('Updates the user institution details when the selection is valid', async () => {
+    const response = await fetch(`${baseUrl}/user_profile`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: encodeForm({
+        faculty: 'Faculty of Science',
+        school: 'School of Mathematics',
+        user: 'morris',
+        university: 'Updated University',
+        viewer: 'morris'
+      })
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(updateUserInstitutions).toHaveBeenCalledWith('morris', {
+      facultyId: 'Faculty of Science',
+      schoolId: 'School of Mathematics',
+      universityId: 'Updated University'
+    })
+    expect(body).toContain('Updated University')
+    expect(body).toContain('Faculty of Science')
+    expect(body).toContain('School of Mathematics')
+  })
+
+  test('Re-renders the profile page when the updated faculty is not from the database list', async () => {
+    getFaculty.mockResolvedValue(null)
+
+    const response = await fetch(`${baseUrl}/user_profile`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: encodeForm({
+        faculty: 'Unknown Faculty',
+        school: 'Electrical and Information Engineering',
+        user: 'morris',
+        university: 'University of the Witwatersrand',
+        viewer: 'morris'
+      })
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(400)
+    expect(updateUserInstitutions).not.toHaveBeenCalled()
+    expect(body).toContain('Choose a faculty from the database list.')
+  })
+
+  test('Rejects institution updates when the viewer is not the profile owner', async () => {
+    getUser.mockResolvedValue({
+      email: 'alice@example.com',
+      facultyId: 'Faculty of Science',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      role: 'student',
+      schoolId: 'School of Chemistry',
+      universityId: 'University of Cape Town',
+      username: 'alice'
+    })
+
+    const response = await fetch(`${baseUrl}/user_profile`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: encodeForm({
+        faculty: 'Faculty of Science',
+        school: 'School of Mathematics',
+        user: 'alice',
+        university: 'Updated University',
+        viewer: 'morris'
+      })
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(403)
+    expect(updateUserInstitutions).not.toHaveBeenCalled()
+    expect(body).toContain('You can only edit your own profile.')
+    expect(body).not.toContain('Update Institution')
+  })
+})

--- a/tests/services/institution_validation.test.js
+++ b/tests/services/institution_validation.test.js
@@ -1,0 +1,129 @@
+jest.mock('../../src/models/university_db', () => ({
+  getFaculty: jest.fn(),
+  getSchool: jest.fn(),
+  getUniversity: jest.fn(),
+  isFacultyInUniversity: jest.fn(),
+  isSchoolInFaculty: jest.fn()
+}))
+
+const {
+  getFaculty,
+  getSchool,
+  getUniversity,
+  isFacultyInUniversity,
+  isSchoolInFaculty
+} = require('../../src/models/university_db')
+const { validateSelection } = require('../../src/services/institution_validation')
+
+describe('institution validation service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getUniversity.mockResolvedValue({ name: 'University of the Witwatersrand' })
+    getFaculty.mockResolvedValue({ name: 'Engineering and the Built Environment' })
+    getSchool.mockResolvedValue({ name: 'Electrical and Information Engineering' })
+    isFacultyInUniversity.mockResolvedValue(true)
+    isSchoolInFaculty.mockResolvedValue(true)
+  })
+
+  test('Defaults missing selection values to empty strings', async () => {
+    getUniversity.mockResolvedValue(null)
+
+    await expect(validateSelection()).resolves.toEqual({
+      error: 'Choose a university from the database list.',
+      isValid: false,
+      statusCode: 400
+    })
+    expect(getUniversity).toHaveBeenCalledWith('')
+  })
+
+  test('Returns an error when the university does not exist', async () => {
+    getUniversity.mockResolvedValue(null)
+
+    await expect(validateSelection({
+      faculty: 'Engineering and the Built Environment',
+      school: 'Electrical and Information Engineering',
+      university: 'crazyTown'
+    })).resolves.toEqual({
+      error: 'Choose a university from the database list.',
+      isValid: false,
+      statusCode: 400
+    })
+  })
+
+  test('Returns an error when the faculty does not exist', async () => {
+    getFaculty.mockResolvedValue(null)
+
+    await expect(validateSelection({
+      faculty: 'crazyTown',
+      school: 'Electrical and Information Engineering',
+      university: 'University of the Witwatersrand'
+    })).resolves.toEqual({
+      error: 'Choose a faculty from the database list.',
+      isValid: false,
+      statusCode: 400
+    })
+  })
+
+  test('Returns an error when the faculty does not belong to the university', async () => {
+    isFacultyInUniversity.mockResolvedValue(false)
+
+    await expect(validateSelection({
+      faculty: 'Engineering and the Built Environment',
+      school: 'Electrical and Information Engineering',
+      university: 'University of the Witwatersrand'
+    })).resolves.toEqual({
+      error: 'Choose a faculty that belongs to the selected university.',
+      isValid: false,
+      statusCode: 400
+    })
+  })
+
+  test('Returns an error when the school does not exist', async () => {
+    getSchool.mockResolvedValue(null)
+
+    await expect(validateSelection({
+      faculty: 'Engineering and the Built Environment',
+      school: 'crazyTown',
+      university: 'University of the Witwatersrand'
+    })).resolves.toEqual({
+      error: 'Choose a school from the database list.',
+      isValid: false,
+      statusCode: 400
+    })
+  })
+
+  test('Returns an error when the school does not belong to the faculty', async () => {
+    isSchoolInFaculty.mockResolvedValue(false)
+
+    await expect(validateSelection({
+      faculty: 'Engineering and the Built Environment',
+      school: 'Electrical and Information Engineering',
+      university: 'University of the Witwatersrand'
+    })).resolves.toEqual({
+      error: 'Choose a school that belongs to the selected faculty.',
+      isValid: false,
+      statusCode: 400
+    })
+  })
+
+  test('Returns matched institution documents when the selection is valid', async () => {
+    const matchedUniversity = { name: 'University of the Witwatersrand' }
+    const matchedFaculty = { name: 'Engineering and the Built Environment' }
+    const matchedSchool = { name: 'Electrical and Information Engineering' }
+
+    getUniversity.mockResolvedValue(matchedUniversity)
+    getFaculty.mockResolvedValue(matchedFaculty)
+    getSchool.mockResolvedValue(matchedSchool)
+
+    await expect(validateSelection({
+      faculty: 'Engineering and the Built Environment',
+      school: 'Electrical and Information Engineering',
+      university: 'University of the Witwatersrand'
+    })).resolves.toEqual({
+      isValid: true,
+      matchedFaculty,
+      matchedSchool,
+      matchedUniversity
+    })
+  })
+})


### PR DESCRIPTION
closes #2 

substantial refactor

-interface university, faculty and school dbs with app
- created an institution validators to allow user to register with their institutional credentials but also to change them later in their profile
- updated register page to include more fields and real-time database checking to ensure university, faculty and school are valid
- real-time database checking includes an autocomplete via datalist (case-insensitive) to make it easier for logging in
- user can select their role (restricted via dropdown menu to either student or lecturer)
- basic query string format via page url to pass username from login page to home page and then to user profile page 
- user profile page added. displays user information
- two fields are included in the query string between login, home and user profile: the user and the viewer's usernames
- user profile is only editable by the user
- viewer just sees details (non-editable)
- update functionality added to user db
-standardJS linting pass
-no user profile clickable forms added (i.e. you can not currently click on another user's profile as there is no way to search for users yet)