### PR TITLE
feat(profile): add lecturer consultation preference settings

### DIFF
--- a/src/models/lecturer_availability_db.js
+++ b/src/models/lecturer_availability_db.js
@@ -1,0 +1,19 @@
+const { getCollection } = require('./db')
+
+const COLLECTION = 'LecturerAvailability'
+
+const getLecturerAvailability = async function (username) {
+  const collection = await getCollection(COLLECTION)
+  return collection.findOne({ username })
+}
+
+const setLecturerAvailability = async function (username, { minStudents, maxStudents, duration, dailyMax }) {
+  const collection = await getCollection(COLLECTION)
+  await collection.updateOne(
+    { username },
+    { $set: { username, minStudents, maxStudents, duration, dailyMax } },
+    { upsert: true }
+  )
+}
+
+module.exports = { getLecturerAvailability, setLecturerAvailability }

--- a/src/models/lecturer_availability_db.js
+++ b/src/models/lecturer_availability_db.js
@@ -2,11 +2,26 @@ const { getCollection } = require('./db')
 
 const COLLECTION = 'LecturerAvailability'
 
+/**
+ * Retrieves the consultation availability settings for a lecturer.
+ * @param {string} username - The lecturer's username.
+ * @returns {Promise<object|null>} The availability document, or null if not set.
+ */
 const getLecturerAvailability = async function (username) {
   const collection = await getCollection(COLLECTION)
   return collection.findOne({ username })
 }
 
+/**
+ * Creates or updates the consultation availability settings for a lecturer.
+ * @param {string} username - The lecturer's username.
+ * @param {object} preferences - The consultation preference values.
+ * @param {number} preferences.minStudents - Minimum students per consultation.
+ * @param {number} preferences.maxStudents - Maximum students per consultation.
+ * @param {number} preferences.duration - Duration of each consultation in minutes.
+ * @param {number} preferences.dailyMax - Maximum number of consultations per day.
+ * @returns {Promise<void>}
+ */
 const setLecturerAvailability = async function (username, { minStudents, maxStudents, duration, dailyMax }) {
   const collection = await getCollection(COLLECTION)
   await collection.updateOne(

--- a/src/public/scripts/consultation_preferences.js
+++ b/src/public/scripts/consultation_preferences.js
@@ -6,6 +6,10 @@ document.addEventListener('DOMContentLoaded', function () {
   const successContainer = document.querySelector('.consult_pref_success_container')
   let successTimeout = null
 
+  /**
+   * Displays an error message and hides any visible success message.
+   * @param {string} message - Error text to display.
+   */
   const showError = function (message) {
     successContainer.hidden = true
     clearTimeout(successTimeout)
@@ -18,6 +22,9 @@ document.addEventListener('DOMContentLoaded', function () {
     errorContainer.hidden = true
   }
 
+  /**
+   * Displays a success message that auto-dismisses after 3 seconds.
+   */
   const showSuccess = function () {
     clearError()
     successContainer.hidden = false

--- a/src/public/scripts/consultation_preferences.js
+++ b/src/public/scripts/consultation_preferences.js
@@ -1,0 +1,59 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const form = document.querySelector('.consultation_preferences_form')
+  if (!form) return
+
+  const errorContainer = document.querySelector('.consult_pref_error_container')
+  const successContainer = document.querySelector('.consult_pref_success_container')
+  let successTimeout = null
+
+  const showError = function (message) {
+    successContainer.hidden = true
+    clearTimeout(successTimeout)
+    errorContainer.textContent = message
+    errorContainer.hidden = false
+  }
+
+  const clearError = function () {
+    errorContainer.textContent = ''
+    errorContainer.hidden = true
+  }
+
+  const showSuccess = function () {
+    clearError()
+    successContainer.hidden = false
+    successTimeout = setTimeout(function () {
+      successContainer.hidden = true
+    }, 3000)
+  }
+
+  form.addEventListener('submit', async function (e) {
+    e.preventDefault()
+
+    const res = await fetch(form.action, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      body: new URLSearchParams(new FormData(form))
+    }).catch(function () { return null })
+
+    if (!res) {
+      showError('Network error. Please try again.')
+      return
+    }
+
+    const data = await res.json().catch(function () { return null })
+
+    if (!data) {
+      showError('An unexpected error occurred.')
+      return
+    }
+
+    if (data.success) {
+      showSuccess()
+    } else {
+      showError(data.error)
+    }
+  })
+})

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -112,6 +112,14 @@ a {
   color: var(--color-error-text);
 }
 
+.success {
+  margin-bottom: 16px;
+  padding: 12px;
+  border-radius: 8px;
+  background: #dcfce7;
+  color: #166534;
+}
+
 .search_status {
   position: absolute;
   left: 0;

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -262,6 +262,59 @@ a {
   align-items: flex-end;
 }
 
+.consultation_preferences_section {
+  max-width: 760px;
+  margin: 32px auto 0;
+  text-align: left;
+}
+
+.consultation_preferences_title {
+  margin: 0 0 16px;
+  padding-top: 24px;
+  border-top: 1px solid var(--color-border);
+}
+
+.consultation_preferences_form {
+  padding: 20px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-surface);
+}
+
+.consultation_preferences_form h3 {
+  margin: 0;
+  text-align: center;
+}
+
+.consultation_preferences_form .consult_flex + .consult_flex {
+  margin-top: 24px;
+}
+
+.consult_flex {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 12px;
+}
+
+.consult_range {
+  flex: 0 0 200px;
+  padding-bottom: 0;
+  text-align: center;
+}
+
+.consult_input {
+  flex: 1;
+  min-width: 80px;
+  padding-bottom: 0;
+}
+
+.consult_separator {
+  padding-bottom: 14px;
+  color: var(--color-secondary);
+  flex-shrink: 0;
+}
+
 @media (max-width: 640px) {
   .register_columns {
     grid-template-columns: 1fr;

--- a/src/routes/user_profile.js
+++ b/src/routes/user_profile.js
@@ -56,13 +56,16 @@ const buildProfileViewState = function (user, overrides = {}) {
 }
 
 const handleConsultationPreferences = async function (req, res, viewer, profileUsername) {
+  const isAjax = req.headers['x-requested-with'] === 'XMLHttpRequest'
   const minStudents = parseInt(req.body.minStudents, 10)
   const maxStudents = parseInt(req.body.maxStudents, 10)
   const duration = parseInt(req.body.duration, 10)
   const dailyMax = parseInt(req.body.dailyMax, 10)
 
   if (isNaN(minStudents) || isNaN(maxStudents) || isNaN(duration) || isNaN(dailyMax)) {
-    return res.redirect(`/user_profile?user=${encodeURIComponent(profileUsername)}&prefError=${encodeURIComponent('Please enter valid numbers for all consultation settings.')}`)
+    const error = 'Please enter valid numbers for all consultation settings.'
+    if (isAjax) return res.json({ success: false, error })
+    return res.redirect(`/user_profile?user=${encodeURIComponent(profileUsername)}&prefError=${encodeURIComponent(error)}`)
   }
 
   try {
@@ -76,6 +79,7 @@ const handleConsultationPreferences = async function (req, res, viewer, profileU
     const resolvedUsername = user.username || profileUsername
 
     if (viewer !== resolvedUsername) {
+      if (isAjax) return res.status(403).json({ success: false, error: 'You can only edit your own profile.' })
       return renderProfile(res, {
         statusCode: 403,
         error: 'You can only edit your own profile.',
@@ -86,22 +90,25 @@ const handleConsultationPreferences = async function (req, res, viewer, profileU
     const validation = validateConsultationPreferences({ minStudents, maxStudents, duration, dailyMax })
 
     if (!validation.isValid) {
-      const consultationPreferences = { minStudents, maxStudents, duration, dailyMax }
+      if (isAjax) return res.status(400).json({ success: false, error: validation.error })
       return renderProfile(res, {
         statusCode: 400,
         ...buildProfileViewState(user, {
           canEdit: true,
           username: resolvedUsername,
-          consultationPreferences,
+          consultationPreferences: { minStudents, maxStudents, duration, dailyMax },
           prefError: validation.error
         })
       })
     }
 
     await setLecturerAvailability(resolvedUsername, { minStudents, maxStudents, duration, dailyMax })
+    if (isAjax) return res.json({ success: true })
     return res.redirect(`/user_profile?user=${encodeURIComponent(resolvedUsername)}`)
   } catch {
-    return res.redirect(`/user_profile?user=${encodeURIComponent(profileUsername)}&prefError=${encodeURIComponent('Sorry. We could not save your consultation preferences.')}`)
+    const error = 'Sorry. We could not save your consultation preferences.'
+    if (isAjax) return res.status(500).json({ success: false, error })
+    return res.redirect(`/user_profile?user=${encodeURIComponent(profileUsername)}&prefError=${encodeURIComponent(error)}`)
   }
 }
 

--- a/src/routes/user_profile.js
+++ b/src/routes/user_profile.js
@@ -7,6 +7,18 @@ const { validateConsultationPreferences } = require('../services/consultation_pr
 
 const router = express.Router()
 
+/**
+ * Renders the user profile page with the given view state.
+ * @param {object} res - Express response object.
+ * @param {object} [options] - View state overrides.
+ * @param {number} [options.statusCode] - HTTP status code to send.
+ * @param {string} [options.error] - General error message to display.
+ * @param {string} [options.prefError] - Consultation preferences error message.
+ * @param {string} [options.username] - Profile owner's username.
+ * @param {boolean} [options.canEdit] - Whether the viewer may edit this profile.
+ * @param {object|null} [options.consultationPreferences] - Saved consultation preferences, or null.
+ * @returns {object} The Express render response.
+ */
 const renderProfile = function (res, {
   statusCode = 200,
   error = '',
@@ -39,6 +51,12 @@ const renderProfile = function (res, {
   })
 }
 
+/**
+ * Builds the default view state object for a user profile from a database user document.
+ * @param {object} user - User document from the database.
+ * @param {object} [overrides] - Values that override the defaults derived from the user document.
+ * @returns {object} View state ready to be passed to renderProfile.
+ */
 const buildProfileViewState = function (user, overrides = {}) {
   return {
     emailAddress: user?.email || '',
@@ -55,6 +73,15 @@ const buildProfileViewState = function (user, overrides = {}) {
   }
 }
 
+/**
+ * Handles saving a lecturer's consultation preferences from a POST request.
+ * Responds with JSON when the request is an AJAX call, or redirects otherwise.
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @param {string} viewer - Username of the currently authenticated user.
+ * @param {string} profileUsername - Username of the profile being edited.
+ * @returns {Promise<object>} The Express response.
+ */
 const handleConsultationPreferences = async function (req, res, viewer, profileUsername) {
   const isAjax = req.headers['x-requested-with'] === 'XMLHttpRequest'
   const minStudents = parseInt(req.body.minStudents, 10)

--- a/src/routes/user_profile.js
+++ b/src/routes/user_profile.js
@@ -2,12 +2,15 @@ const express = require('express')
 const { connectToDatabase } = require('../models/db')
 const { getUser, updateUserInstitutions } = require('../models/user_db')
 const { validateSelection } = require('../services/institution_validation')
+const { getLecturerAvailability, setLecturerAvailability } = require('../models/lecturer_availability_db')
+const { validateConsultationPreferences } = require('../services/consultation_preferences_validation')
 
 const router = express.Router()
 
 const renderProfile = function (res, {
   statusCode = 200,
   error = '',
+  prefError = '',
   emailAddress = '',
   username = '',
   canEdit = false,
@@ -16,11 +19,13 @@ const renderProfile = function (res, {
   school = '',
   role = '',
   name = '',
-  surname = ''
+  surname = '',
+  consultationPreferences = null
 } = {}) {
   return res.status(statusCode).render('user_profile', {
     title: 'User Profile',
     error,
+    prefError,
     emailAddress,
     username,
     canEdit,
@@ -29,7 +34,8 @@ const renderProfile = function (res, {
     school,
     role,
     name,
-    surname
+    surname,
+    consultationPreferences
   })
 }
 
@@ -44,13 +50,65 @@ const buildProfileViewState = function (user, overrides = {}) {
     role: user?.role || '',
     name: user?.firstName || '',
     surname: user?.lastName || '',
+    consultationPreferences: null,
     ...overrides
+  }
+}
+
+const handleConsultationPreferences = async function (req, res, viewer, profileUsername) {
+  const minStudents = parseInt(req.body.minStudents, 10)
+  const maxStudents = parseInt(req.body.maxStudents, 10)
+  const duration = parseInt(req.body.duration, 10)
+  const dailyMax = parseInt(req.body.dailyMax, 10)
+
+  if (isNaN(minStudents) || isNaN(maxStudents) || isNaN(duration) || isNaN(dailyMax)) {
+    return res.redirect(`/user_profile?user=${encodeURIComponent(profileUsername)}&prefError=${encodeURIComponent('Please enter valid numbers for all consultation settings.')}`)
+  }
+
+  try {
+    await connectToDatabase()
+    const user = await getUser(profileUsername)
+
+    if (!user) {
+      return res.redirect('/login')
+    }
+
+    const resolvedUsername = user.username || profileUsername
+
+    if (viewer !== resolvedUsername) {
+      return renderProfile(res, {
+        statusCode: 403,
+        error: 'You can only edit your own profile.',
+        ...buildProfileViewState(user, { canEdit: false, username: resolvedUsername })
+      })
+    }
+
+    const validation = validateConsultationPreferences({ minStudents, maxStudents, duration, dailyMax })
+
+    if (!validation.isValid) {
+      const consultationPreferences = { minStudents, maxStudents, duration, dailyMax }
+      return renderProfile(res, {
+        statusCode: 400,
+        ...buildProfileViewState(user, {
+          canEdit: true,
+          username: resolvedUsername,
+          consultationPreferences,
+          prefError: validation.error
+        })
+      })
+    }
+
+    await setLecturerAvailability(resolvedUsername, { minStudents, maxStudents, duration, dailyMax })
+    return res.redirect(`/user_profile?user=${encodeURIComponent(resolvedUsername)}`)
+  } catch {
+    return res.redirect(`/user_profile?user=${encodeURIComponent(profileUsername)}&prefError=${encodeURIComponent('Sorry. We could not save your consultation preferences.')}`)
   }
 }
 
 router.get('/', async (req, res) => {
   const viewer = req.session?.user?.username || ''
   const profileUsername = req.query.user?.trim() || req.query.username?.trim() || viewer
+  const prefError = req.query.prefError?.trim() || ''
 
   if (!profileUsername) {
     return res.redirect('/login')
@@ -65,10 +123,17 @@ router.get('/', async (req, res) => {
     }
 
     const resolvedUsername = user.username || profileUsername
+    let consultationPreferences = null
+
+    if (user.role === 'lecturer') {
+      consultationPreferences = await getLecturerAvailability(resolvedUsername)
+    }
 
     return renderProfile(res, buildProfileViewState(user, {
       canEdit: viewer === resolvedUsername,
-      username: resolvedUsername
+      username: resolvedUsername,
+      consultationPreferences,
+      prefError
     }))
   } catch (error) {
     return renderProfile(res, {
@@ -82,13 +147,18 @@ router.get('/', async (req, res) => {
 router.post('/', async (req, res) => {
   const viewer = req.session?.user?.username || ''
   const profileUsername = req.body.user?.trim() || req.body.username?.trim() || viewer
-  const university = req.body.university?.trim() || ''
-  const faculty = req.body.faculty?.trim() || ''
-  const school = req.body.school?.trim() || ''
 
   if (!profileUsername) {
     return res.redirect('/login')
   }
+
+  if (req.body.formType === 'consultationPreferences') {
+    return handleConsultationPreferences(req, res, viewer, profileUsername)
+  }
+
+  const university = req.body.university?.trim() || ''
+  const faculty = req.body.faculty?.trim() || ''
+  const school = req.body.school?.trim() || ''
 
   try {
     await connectToDatabase()

--- a/src/services/consultation_preferences_validation.js
+++ b/src/services/consultation_preferences_validation.js
@@ -1,0 +1,16 @@
+const MAX_DAILY_CONSULTATION_MINUTES = 480
+
+const validateConsultationPreferences = function ({ minStudents, maxStudents, duration, dailyMax }) {
+  if (minStudents < 0 || maxStudents < 0 || duration < 0 || dailyMax < 0) {
+    return { isValid: false, error: 'Consultation settings cannot be negative.' }
+  }
+  if (minStudents > maxStudents) {
+    return { isValid: false, error: 'Minimum students cannot exceed maximum students.' }
+  }
+  if (duration * dailyMax > MAX_DAILY_CONSULTATION_MINUTES) {
+    return { isValid: false, error: `Total daily consultation time (${duration * dailyMax} min) exceeds your availability of ${MAX_DAILY_CONSULTATION_MINUTES} minutes.` }
+  }
+  return { isValid: true, error: '' }
+}
+
+module.exports = { validateConsultationPreferences }

--- a/src/services/consultation_preferences_validation.js
+++ b/src/services/consultation_preferences_validation.js
@@ -1,5 +1,16 @@
 const MAX_DAILY_CONSULTATION_MINUTES = 480
 
+/**
+ * Validates a lecturer's consultation preference settings.
+ * Rejects negative values, a min/max student inversion, and a total daily
+ * consultation time that exceeds the maximum availability of 480 minutes.
+ * @param {object} preferences - The consultation preference values to validate.
+ * @param {number} preferences.minStudents - Minimum students per consultation.
+ * @param {number} preferences.maxStudents - Maximum students per consultation.
+ * @param {number} preferences.duration - Duration of each consultation in minutes.
+ * @param {number} preferences.dailyMax - Maximum number of consultations per day.
+ * @returns {{isValid: boolean, error: string}} Validation result with an error message if invalid.
+ */
 const validateConsultationPreferences = function ({ minStudents, maxStudents, duration, dailyMax }) {
   if (minStudents < 0 || maxStudents < 0 || duration < 0 || dailyMax < 0) {
     return { isValid: false, error: 'Consultation settings cannot be negative.' }

--- a/src/views/user_profile.ejs
+++ b/src/views/user_profile.ejs
@@ -10,7 +10,7 @@
 <body class="page page_home">
   <main class="card card_even_wider text_center">
     <header>
-      <h1>Hello <%= username %></h1>
+      <h1><%= canEdit ? `Hello, ${username}` : `${username}'s Profile` %></h1>
     </header>
 
     <% if (error) { %>
@@ -125,49 +125,56 @@
         <input type="hidden" name="username" value="<%= username %>">
         <input type="hidden" name="formType" value="consultationPreferences">
 
-        <label>
-          Minimum Students per Consultation
-          <input
-            type="number"
-            name="minStudents"
-            value="<%= consultationPreferences ? consultationPreferences.minStudents : '' %>"
-            min="0"
-            required
-          >
-        </label>
+        <h3>Student Attendance Range</h3>
+        <div class="consult_flex">
+          <label class="consult_range">
+            Min
+            <input
+              type="number"
+              name="minStudents"
+              value="<%= consultationPreferences ? consultationPreferences.minStudents : '' %>"
+              min="0"
+              required
+            >
+          </label>
 
-        <label>
-          Maximum Students per Consultation
-          <input
-            type="number"
-            name="maxStudents"
-            value="<%= consultationPreferences ? consultationPreferences.maxStudents : '' %>"
-            min="0"
-            required
-          >
-        </label>
+          <span class="consult_separator">–</span>
 
-        <label>
-          Duration per Consultation (minutes)
-          <input
-            type="number"
-            name="duration"
-            value="<%= consultationPreferences ? consultationPreferences.duration : '' %>"
-            min="0"
-            required
-          >
-        </label>
+          <label class="consult_range">
+            Max
+            <input
+              type="number"
+              name="maxStudents"
+              value="<%= consultationPreferences ? consultationPreferences.maxStudents : '' %>"
+              min="0"
+              required
+            >
+          </label>
+        </div>
 
-        <label>
-          Daily Maximum Consultations
-          <input
-            type="number"
-            name="dailyMax"
-            value="<%= consultationPreferences ? consultationPreferences.dailyMax : '' %>"
-            min="0"
-            required
-          >
-        </label>
+        <div class="consult_flex">
+          <label class="consult_input">
+            Duration per Consultation (minutes)
+            <input
+              type="number"
+              name="duration"
+              value="<%= consultationPreferences ? consultationPreferences.duration : '' %>"
+              min="0"
+              required
+            >
+          </label>
+
+          <label class="consult_input">
+            Daily Maximum Consultations
+            <input
+              type="number"
+              name="dailyMax"
+              value="<%= consultationPreferences ? consultationPreferences.dailyMax : '' %>"
+              min="0"
+              required
+            >
+          </label>
+        </div>
 
         <button type="submit">Save Consultation Preferences</button>
       </form>

--- a/src/views/user_profile.ejs
+++ b/src/views/user_profile.ejs
@@ -6,6 +6,7 @@
   <title><%= title %></title>
   <link rel="stylesheet" href="/styles/main.css">
   <script src="/scripts/search.js" defer></script>
+  <script src="/scripts/consultation_preferences.js" defer></script>
 </head>
 <body class="page page_home">
   <main class="card card_even_wider text_center">
@@ -116,9 +117,8 @@
     <section class="consultation_preferences_section">
       <h2 class="consultation_preferences_title">Consultation Preferences</h2>
 
-      <% if (prefError) { %>
-        <div class="error"><%= prefError %></div>
-      <% } %>
+      <div class="error consult_pref_error_container" hidden></div>
+      <div class="success consult_pref_success_container" hidden>Consultation preferences saved successfully.</div>
 
       <% if (canEdit) { %>
       <form class="consultation_preferences_form" action="/user_profile?user=<%= encodeURIComponent(username) %>" method="post">

--- a/src/views/user_profile.ejs
+++ b/src/views/user_profile.ejs
@@ -112,6 +112,88 @@
       </div>
     </section>
 
+    <% if (role === 'lecturer') { %>
+    <section class="consultation_preferences_section">
+      <h2 class="consultation_preferences_title">Consultation Preferences</h2>
+
+      <% if (prefError) { %>
+        <div class="error"><%= prefError %></div>
+      <% } %>
+
+      <% if (canEdit) { %>
+      <form class="consultation_preferences_form" action="/user_profile?user=<%= encodeURIComponent(username) %>" method="post">
+        <input type="hidden" name="username" value="<%= username %>">
+        <input type="hidden" name="formType" value="consultationPreferences">
+
+        <label>
+          Minimum Students per Consultation
+          <input
+            type="number"
+            name="minStudents"
+            value="<%= consultationPreferences ? consultationPreferences.minStudents : '' %>"
+            min="0"
+            required
+          >
+        </label>
+
+        <label>
+          Maximum Students per Consultation
+          <input
+            type="number"
+            name="maxStudents"
+            value="<%= consultationPreferences ? consultationPreferences.maxStudents : '' %>"
+            min="0"
+            required
+          >
+        </label>
+
+        <label>
+          Duration per Consultation (minutes)
+          <input
+            type="number"
+            name="duration"
+            value="<%= consultationPreferences ? consultationPreferences.duration : '' %>"
+            min="0"
+            required
+          >
+        </label>
+
+        <label>
+          Daily Maximum Consultations
+          <input
+            type="number"
+            name="dailyMax"
+            value="<%= consultationPreferences ? consultationPreferences.dailyMax : '' %>"
+            min="0"
+            required
+          >
+        </label>
+
+        <button type="submit">Save Consultation Preferences</button>
+      </form>
+      <% } else { %>
+      <div class="profile_details">
+        <div class="profile_detail">
+          <h3 class="profile_detail_label">Min Students per Consultation</h3>
+          <p class="profile_detail_value"><%= consultationPreferences ? consultationPreferences.minStudents : 'Not set' %></p>
+        </div>
+        <div class="profile_detail">
+          <h3 class="profile_detail_label">Max Students per Consultation</h3>
+          <p class="profile_detail_value"><%= consultationPreferences ? consultationPreferences.maxStudents : 'Not set' %></p>
+        </div>
+        <div class="profile_detail">
+          <h3 class="profile_detail_label">Duration per Consultation (minutes)</h3>
+          <p class="profile_detail_value"><%= consultationPreferences ? consultationPreferences.duration : 'Not set' %></p>
+        </div>
+        <div class="profile_detail">
+          <h3 class="profile_detail_label">Daily Maximum Consultations</h3>
+          <p class="profile_detail_value"><%= consultationPreferences ? consultationPreferences.dailyMax : 'Not set' %></p>
+        </div>
+      </div>
+      <% } %>
+    </section>
+    <% } %>
+
     <a class="back_link" href="/home">Home</a>
   </main>
 </body>

--- a/tests/models/lecturer_availability_db.test.js
+++ b/tests/models/lecturer_availability_db.test.js
@@ -1,0 +1,51 @@
+jest.mock('../../src/models/db', () => ({
+  getCollection: jest.fn()
+}))
+
+const { getCollection } = require('../../src/models/db')
+const { getLecturerAvailability, setLecturerAvailability } = require('../../src/models/lecturer_availability_db')
+
+describe('lecturer availability database operations', () => {
+  let mockCollection
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCollection = {
+      findOne: jest.fn(),
+      updateOne: jest.fn()
+    }
+    getCollection.mockResolvedValue(mockCollection)
+  })
+
+  test('getLecturerAvailability queries the LecturerAvailability collection by username', async () => {
+    const preferences = { username: 'dr_jones', minStudents: 2, maxStudents: 10, duration: 60, dailyMax: 4 }
+    mockCollection.findOne.mockResolvedValue(preferences)
+
+    const result = await getLecturerAvailability('dr_jones')
+
+    expect(getCollection).toHaveBeenCalledWith('LecturerAvailability')
+    expect(mockCollection.findOne).toHaveBeenCalledWith({ username: 'dr_jones' })
+    expect(result).toEqual(preferences)
+  })
+
+  test('getLecturerAvailability returns null when no preferences are set', async () => {
+    mockCollection.findOne.mockResolvedValue(null)
+
+    const result = await getLecturerAvailability('dr_jones')
+
+    expect(result).toBeNull()
+  })
+
+  test('setLecturerAvailability upserts the preferences document for the given username', async () => {
+    mockCollection.updateOne.mockResolvedValue({ acknowledged: true })
+
+    await setLecturerAvailability('dr_jones', { minStudents: 2, maxStudents: 10, duration: 60, dailyMax: 4 })
+
+    expect(getCollection).toHaveBeenCalledWith('LecturerAvailability')
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      { username: 'dr_jones' },
+      { $set: { username: 'dr_jones', minStudents: 2, maxStudents: 10, duration: 60, dailyMax: 4 } },
+      { upsert: true }
+    )
+  })
+})

--- a/tests/routes/user_profile.test.js
+++ b/tests/routes/user_profile.test.js
@@ -1,3 +1,8 @@
+jest.mock('../../src/models/lecturer_availability_db', () => ({
+  getLecturerAvailability: jest.fn(),
+  setLecturerAvailability: jest.fn()
+}))
+
 jest.mock('../../src/models/db', () => ({
   closeDatabaseConnection: jest.fn(),
   connectToDatabase: jest.fn().mockResolvedValue(undefined),
@@ -29,6 +34,7 @@ const http = require('node:http')
 
 const { connectToDatabase } = require('../../src/models/db')
 const { getUser, updateUserInstitutions } = require('../../src/models/user_db')
+const { getLecturerAvailability, setLecturerAvailability } = require('../../src/models/lecturer_availability_db')
 const {
   getFaculty,
   getSchool,
@@ -120,6 +126,8 @@ describe('user profile route', () => {
     getUniversity.mockResolvedValue({ name: 'University of the Witwatersrand' })
     isFacultyInUniversity.mockResolvedValue(true)
     isSchoolInFaculty.mockResolvedValue(true)
+    getLecturerAvailability.mockResolvedValue(null)
+    setLecturerAvailability.mockResolvedValue(undefined)
   })
 
   test('Redirects unauthenticated users to login before rendering the profile page', async () => {
@@ -145,7 +153,7 @@ describe('user profile route', () => {
     expect(response.status).toBe(200)
     expect(connectToDatabase).toHaveBeenCalledTimes(1)
     expect(getUser).toHaveBeenCalledWith('morris')
-    expect(body).toContain('Hello morris')
+    expect(body).toContain('Hello, morris')
     expect(body).toContain('Update Institution')
     expect(body).toContain('Morris')
     expect(body).toContain('Wits')
@@ -179,7 +187,7 @@ describe('user profile route', () => {
 
     expect(response.status).toBe(200)
     expect(getUser).toHaveBeenCalledWith('alice')
-    expect(body).toContain('Hello alice')
+    expect(body).toContain('alice&#39;s Profile')
     expect(body).not.toContain('Update Institution')
     expect(body).toContain('alice@example.com')
     expect(body).toContain('href="/home"')
@@ -307,5 +315,150 @@ describe('user profile route', () => {
     expect(updateUserInstitutions).not.toHaveBeenCalled()
     expect(body).toContain('You can only edit your own profile.')
     expect(body).not.toContain('Update Institution')
+  })
+
+  test('Renders the consultation preferences form when a lecturer views their own profile', async () => {
+    const sessionCookie = await loginAs({ role: 'lecturer', username: 'dr_jones' })
+    getUser.mockResolvedValueOnce(await buildUser({ role: 'lecturer', username: 'dr_jones' }))
+    getLecturerAvailability.mockResolvedValueOnce({ minStudents: 2, maxStudents: 10, duration: 60, dailyMax: 4 })
+
+    const response = await fetch(`${baseUrl}/user_profile?user=dr_jones`, {
+      headers: { cookie: sessionCookie }
+    })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(getLecturerAvailability).toHaveBeenCalledWith('dr_jones')
+    expect(body).toContain('Consultation Preferences')
+    expect(body).toContain('Save Consultation Preferences')
+  })
+
+  test('Renders read-only consultation preferences when a student views a lecturer profile', async () => {
+    const sessionCookie = await loginAs()
+    getUser.mockResolvedValueOnce(await buildUser({ role: 'lecturer', username: 'dr_jones', email: 'dr@example.com' }))
+    getLecturerAvailability.mockResolvedValueOnce({ minStudents: 2, maxStudents: 10, duration: 60, dailyMax: 4 })
+
+    const response = await fetch(`${baseUrl}/user_profile?user=dr_jones`, {
+      headers: { cookie: sessionCookie }
+    })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(getLecturerAvailability).toHaveBeenCalledWith('dr_jones')
+    expect(body).toContain('Consultation Preferences')
+    expect(body).not.toContain('Save Consultation Preferences')
+  })
+
+  test('Does not render the consultation preferences section for student profiles', async () => {
+    const sessionCookie = await loginAs()
+
+    const response = await fetch(`${baseUrl}/user_profile?user=morris`, {
+      headers: { cookie: sessionCookie }
+    })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(getLecturerAvailability).not.toHaveBeenCalled()
+    expect(body).not.toContain('Consultation Preferences')
+  })
+
+  test('Saves consultation preferences and returns JSON success for an AJAX request', async () => {
+    const sessionCookie = await loginAs({ role: 'lecturer', username: 'dr_jones' })
+    getUser.mockResolvedValueOnce(await buildUser({ role: 'lecturer', username: 'dr_jones' }))
+
+    const response = await fetch(`${baseUrl}/user_profile`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-requested-with': 'XMLHttpRequest',
+        cookie: sessionCookie
+      },
+      body: encodeForm({ formType: 'consultationPreferences', username: 'dr_jones', minStudents: '2', maxStudents: '10', duration: '60', dailyMax: '4' })
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(setLecturerAvailability).toHaveBeenCalledWith('dr_jones', { minStudents: 2, maxStudents: 10, duration: 60, dailyMax: 4 })
+    expect(data).toEqual({ success: true })
+  })
+
+  test('Returns a JSON error when a consultation preference value is negative', async () => {
+    const sessionCookie = await loginAs({ role: 'lecturer', username: 'dr_jones' })
+    getUser.mockResolvedValueOnce(await buildUser({ role: 'lecturer', username: 'dr_jones' }))
+
+    const response = await fetch(`${baseUrl}/user_profile`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-requested-with': 'XMLHttpRequest',
+        cookie: sessionCookie
+      },
+      body: encodeForm({ formType: 'consultationPreferences', username: 'dr_jones', minStudents: '-1', maxStudents: '10', duration: '60', dailyMax: '4' })
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(setLecturerAvailability).not.toHaveBeenCalled()
+    expect(data).toEqual({ success: false, error: 'Consultation settings cannot be negative.' })
+  })
+
+  test('Returns a JSON error when minimum students exceed maximum students', async () => {
+    const sessionCookie = await loginAs({ role: 'lecturer', username: 'dr_jones' })
+    getUser.mockResolvedValueOnce(await buildUser({ role: 'lecturer', username: 'dr_jones' }))
+
+    const response = await fetch(`${baseUrl}/user_profile`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-requested-with': 'XMLHttpRequest',
+        cookie: sessionCookie
+      },
+      body: encodeForm({ formType: 'consultationPreferences', username: 'dr_jones', minStudents: '10', maxStudents: '5', duration: '60', dailyMax: '4' })
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(setLecturerAvailability).not.toHaveBeenCalled()
+    expect(data).toEqual({ success: false, error: 'Minimum students cannot exceed maximum students.' })
+  })
+
+  test('Returns a JSON error when total daily consultation time exceeds 480 minutes', async () => {
+    const sessionCookie = await loginAs({ role: 'lecturer', username: 'dr_jones' })
+    getUser.mockResolvedValueOnce(await buildUser({ role: 'lecturer', username: 'dr_jones' }))
+
+    const response = await fetch(`${baseUrl}/user_profile`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-requested-with': 'XMLHttpRequest',
+        cookie: sessionCookie
+      },
+      body: encodeForm({ formType: 'consultationPreferences', username: 'dr_jones', minStudents: '2', maxStudents: '10', duration: '120', dailyMax: '5' })
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(setLecturerAvailability).not.toHaveBeenCalled()
+    expect(data.success).toBe(false)
+  })
+
+  test('Returns a 403 JSON error when the viewer is not the profile owner', async () => {
+    const sessionCookie = await loginAs({ role: 'lecturer', username: 'dr_jones' })
+    getUser.mockResolvedValueOnce(await buildUser({ role: 'lecturer', username: 'prof_smith', email: 'prof@example.com' }))
+
+    const response = await fetch(`${baseUrl}/user_profile`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-requested-with': 'XMLHttpRequest',
+        cookie: sessionCookie
+      },
+      body: encodeForm({ formType: 'consultationPreferences', username: 'prof_smith', minStudents: '2', maxStudents: '10', duration: '60', dailyMax: '4' })
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(setLecturerAvailability).not.toHaveBeenCalled()
+    expect(data).toEqual({ success: false, error: 'You can only edit your own profile.' })
   })
 })

--- a/tests/services/consultation_preferences_validation.test.js
+++ b/tests/services/consultation_preferences_validation.test.js
@@ -1,0 +1,48 @@
+const { validateConsultationPreferences } = require('../../src/services/consultation_preferences_validation')
+
+describe('consultation preferences validation', () => {
+  test('Returns invalid when minStudents is negative', () => {
+    expect(validateConsultationPreferences({ minStudents: -1, maxStudents: 10, duration: 60, dailyMax: 4 }))
+      .toEqual({ isValid: false, error: 'Consultation settings cannot be negative.' })
+  })
+
+  test('Returns invalid when maxStudents is negative', () => {
+    expect(validateConsultationPreferences({ minStudents: 2, maxStudents: -1, duration: 60, dailyMax: 4 }))
+      .toEqual({ isValid: false, error: 'Consultation settings cannot be negative.' })
+  })
+
+  test('Returns invalid when duration is negative', () => {
+    expect(validateConsultationPreferences({ minStudents: 2, maxStudents: 10, duration: -1, dailyMax: 4 }))
+      .toEqual({ isValid: false, error: 'Consultation settings cannot be negative.' })
+  })
+
+  test('Returns invalid when dailyMax is negative', () => {
+    expect(validateConsultationPreferences({ minStudents: 2, maxStudents: 10, duration: 60, dailyMax: -1 }))
+      .toEqual({ isValid: false, error: 'Consultation settings cannot be negative.' })
+  })
+
+  test('Returns invalid when minStudents exceeds maxStudents', () => {
+    expect(validateConsultationPreferences({ minStudents: 10, maxStudents: 5, duration: 60, dailyMax: 4 }))
+      .toEqual({ isValid: false, error: 'Minimum students cannot exceed maximum students.' })
+  })
+
+  test('Returns invalid when duration times dailyMax exceeds 480 minutes', () => {
+    expect(validateConsultationPreferences({ minStudents: 2, maxStudents: 10, duration: 120, dailyMax: 5 }))
+      .toEqual({ isValid: false, error: 'Total daily consultation time (600 min) exceeds your availability of 480 minutes.' })
+  })
+
+  test('Returns valid when minStudents equals maxStudents', () => {
+    expect(validateConsultationPreferences({ minStudents: 5, maxStudents: 5, duration: 60, dailyMax: 4 }))
+      .toEqual({ isValid: true, error: '' })
+  })
+
+  test('Returns valid when duration times dailyMax equals exactly 480 minutes', () => {
+    expect(validateConsultationPreferences({ minStudents: 2, maxStudents: 10, duration: 60, dailyMax: 8 }))
+      .toEqual({ isValid: true, error: '' })
+  })
+
+  test('Returns valid for a correct set of preferences', () => {
+    expect(validateConsultationPreferences({ minStudents: 2, maxStudents: 10, duration: 60, dailyMax: 4 }))
+      .toEqual({ isValid: true, error: '' })
+  })
+})


### PR DESCRIPTION
closes #5 
## Summary

- Adds a **Consultation Preferences** section to the lecturer's User Profile page, allowing lecturers to configure min/max students per consultation, duration (minutes), and daily maximum consultations
- Preferences are saved to a new `LecturerAvailability` collection and displayed as read-only to any user viewing a lecturer's profile
- Form submission is handled via AJAX — preferences save without a full page reload, with inline success and error feedback
- Profile page heading now contextually reads **"Hello, \<username\>"** for the profile owner and **"\<username\>'s Profile"** for other viewers

## Known limitation

The acceptance criterion requiring calendar days to be highlighted when a lecturer's daily consultation maximum is reached **cannot be implemented yet** — it depends on consultation booking data which does not exist until the schedule consultation feature is built.

## Test plan

- [ ] Log in as a lecturer and navigate to your User Profile — confirm the Consultation Preferences form is visible
- [ ] Submit valid preferences — confirm the green success banner appears without a page reload
- [ ] Submit negative values — confirm the red error banner appears
- [ ] Submit values where `duration × dailyMax > 480` — confirm the error banner appears
- [ ] Submit values where `minStudents > maxStudents` — confirm the error banner appears
- [ ] Log in as a student and navigate to a lecturer's profile — confirm preferences are visible but the save form is not
- [ ] Log in as a student and navigate to another student's profile — confirm no Consultation Preferences section is shown