### PR TITLE
Lecturer availability settings

### DIFF
--- a/src/models/lecturer_availability_db.js
+++ b/src/models/lecturer_availability_db.js
@@ -4,6 +4,10 @@ const COLLECTION = 'LecturerAvailability'
 
 /**
  * Retrieves the consultation availability settings for a lecturer.
+ * The returned document may include:
+ * - `minStudents`, `maxStudents`, `duration`, `dailyMax`
+ * - `weeklyAvailability`: array of objects describing weekly slots (e.g. `{ day: 'monday', startTime: '09:00', endTime: '17:00' }`)
+ * - `exceptionDates`: array of ISO date strings where the lecturer is unavailable
  * @param {string} username - The lecturer's username.
  * @returns {Promise<object|null>} The availability document, or null if not set.
  */
@@ -14,19 +18,40 @@ const getLecturerAvailability = async function (username) {
 
 /**
  * Creates or updates the consultation availability settings for a lecturer.
+ * Only fields provided in `preferences` will be upserted, preserving existing values for omitted keys.
  * @param {string} username - The lecturer's username.
  * @param {object} preferences - The consultation preference values.
- * @param {number} preferences.minStudents - Minimum students per consultation.
- * @param {number} preferences.maxStudents - Maximum students per consultation.
- * @param {number} preferences.duration - Duration of each consultation in minutes.
- * @param {number} preferences.dailyMax - Maximum number of consultations per day.
+ * @param {number} [preferences.minStudents] - Minimum students per consultation.
+ * @param {number} [preferences.maxStudents] - Maximum students per consultation.
+ * @param {number} [preferences.duration] - Duration of each consultation in minutes.
+ * @param {number} [preferences.dailyMax] - Maximum number of consultations per day.
+ * @param {Array<object>} [preferences.weeklyAvailability] - Weekly availability entries.
+ * @param {Array<string>} [preferences.exceptionDates] - Specific non-repeating unavailable dates (ISO strings).
  * @returns {Promise<void>}
  */
-const setLecturerAvailability = async function (username, { minStudents, maxStudents, duration, dailyMax }) {
+const setLecturerAvailability = async function (username, preferences = {}) {
   const collection = await getCollection(COLLECTION)
+  const {
+    minStudents,
+    maxStudents,
+    duration,
+    dailyMax,
+    weeklyAvailability,
+    exceptionDates
+  } = preferences
+
+  const setFields = { username }
+
+  if (typeof minStudents !== 'undefined') setFields.minStudents = minStudents
+  if (typeof maxStudents !== 'undefined') setFields.maxStudents = maxStudents
+  if (typeof duration !== 'undefined') setFields.duration = duration
+  if (typeof dailyMax !== 'undefined') setFields.dailyMax = dailyMax
+  if (typeof weeklyAvailability !== 'undefined') setFields.weeklyAvailability = weeklyAvailability
+  if (typeof exceptionDates !== 'undefined') setFields.exceptionDates = exceptionDates
+
   await collection.updateOne(
     { username },
-    { $set: { username, minStudents, maxStudents, duration, dailyMax } },
+    { $set: setFields },
     { upsert: true }
   )
 }

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -250,6 +250,43 @@ a {
   vertical-align: top;
 }
 
+.calendar_day_content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: space-between;
+  min-height: 100%;
+  gap: 6px;
+}
+
+.calendar_day_number {
+  font-weight: 700;
+}
+
+.calendar_day_note {
+  font-size: 0.75rem;
+  line-height: 1.2;
+  color: var(--color-secondary);
+  text-align: right;
+}
+
+.calendar_day_available {
+  background: #dcfce7;
+}
+
+.calendar_day_available .calendar_day_note {
+  color: #166534;
+}
+
+.calendar_day_unavailable {
+  background: var(--color-error-bg);
+}
+
+.calendar_day_unavailable .calendar_day_note,
+.calendar_day_unavailable .calendar_day_number {
+  color: var(--color-error-text);
+}
+
 .calendar_day_empty {
   background: #f8fafc;
 }

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -91,6 +91,16 @@ select {
   margin: 0;
 }
 
+textarea {
+  padding: 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  font-size: 1rem;
+  font-family: inherit;
+  margin: 0;
+  resize: vertical;
+}
+
 button,
 a {
   display: inline-block;
@@ -302,6 +312,7 @@ a {
   display: flex;
   align-items: flex-end;
   justify-content: center;
+  flex-wrap: wrap;
   gap: 12px;
 }
 

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -2,6 +2,7 @@
 
 const express = require('express')
 const { connectToDatabase } = require('../models/db')
+const { getLecturerAvailability } = require('../models/lecturer_availability_db')
 const { searchLecturers } = require('../models/user_db')
 const { buildCurrentMonthCalendar } = require('../utils/calendar')
 
@@ -18,9 +19,19 @@ router.get('/', async (req, res) => {
   const role = req.session?.user?.role || ''
   const username = req.session?.user?.username || ''
   const universityId = req.session?.user?.universityId || ''
-  const calendar = buildCurrentMonthCalendar()
   const title = HOME_TITLES[role] || 'Home'
   const homeTitle = HOME_TITLES[role] || 'Home'
+  let calendar = buildCurrentMonthCalendar()
+
+  if (role === 'lecturer' && username) {
+    try {
+      await connectToDatabase()
+      const availabilityPreferences = await getLecturerAvailability(username)
+      calendar = buildCurrentMonthCalendar(new Date(), availabilityPreferences)
+    } catch {
+      calendar = buildCurrentMonthCalendar()
+    }
+  }
 
   if (role !== 'student') {
     return res.render('home', { title, homeTitle, role, username, calendar, lecturers: [], faculties: [], schools: [], query: '', facultyId: '', schoolId: '', page: 1, totalPages: 0 })

--- a/src/routes/user_profile.js
+++ b/src/routes/user_profile.js
@@ -7,6 +7,19 @@ const { validateConsultationPreferences } = require('../services/consultation_pr
 
 const router = express.Router()
 
+const WEEKDAYS = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday'
+]
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+const TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/
+
 /**
  * Renders the user profile page with the given view state.
  * @param {object} res - Express response object.
@@ -32,7 +45,8 @@ const renderProfile = function (res, {
   role = '',
   name = '',
   surname = '',
-  consultationPreferences = null
+  consultationPreferences = null,
+  weekdays = WEEKDAYS
 } = {}) {
   return res.status(statusCode).render('user_profile', {
     title: 'User Profile',
@@ -47,7 +61,8 @@ const renderProfile = function (res, {
     role,
     name,
     surname,
-    consultationPreferences
+    consultationPreferences,
+    weekdays
   })
 }
 
@@ -69,8 +84,108 @@ const buildProfileViewState = function (user, overrides = {}) {
     name: user?.firstName || '',
     surname: user?.lastName || '',
     consultationPreferences: null,
+    weekdays: WEEKDAYS,
     ...overrides
   }
+}
+
+/**
+ * Returns a trimmed string field from a form body.
+ * @param {object} formValues - Submitted form values.
+ * @param {string} fieldName - Field name to read.
+ * @returns {string} The trimmed field value or an empty string.
+ */
+const getTrimmedField = function (formValues, fieldName) {
+  if (typeof formValues[fieldName] !== 'string') {
+    return ''
+  }
+
+  return formValues[fieldName].trim()
+}
+
+/**
+ * Builds weekly availability entries from the lecturer settings form.
+ * @param {object} formValues - Submitted form values.
+ * @returns {Array<object>} Weekly availability entries.
+ */
+const buildWeeklyAvailability = function (formValues) {
+  const weeklyAvailability = []
+
+  for (const day of WEEKDAYS) {
+    if (getTrimmedField(formValues, `availability_${day}`) !== 'available') {
+      continue
+    }
+
+    weeklyAvailability.push({
+      day,
+      startTime: getTrimmedField(formValues, `start_time_${day}`),
+      endTime: getTrimmedField(formValues, `end_time_${day}`)
+    })
+  }
+
+  return weeklyAvailability
+}
+
+/**
+ * Builds the list of specific unavailable dates from the lecturer settings form.
+ * @param {string} rawDates - Comma-separated or line-separated date values.
+ * @returns {Array<string>} Unique ISO date strings.
+ */
+const parseExceptionDates = function (rawDates) {
+  if (!rawDates) {
+    return []
+  }
+
+  return Array.from(new Set(
+    rawDates
+      .split(/[\n,]+/)
+      .map(function (date) { return date.trim() })
+      .filter(Boolean)
+  ))
+}
+
+/**
+ * Checks whether a YYYY-MM-DD string is a real calendar date.
+ * @param {string} value - Date string to validate.
+ * @returns {boolean} True when the value is a valid ISO date.
+ */
+const isValidIsoDate = function (value) {
+  if (!ISO_DATE_PATTERN.test(value)) {
+    return false
+  }
+
+  const [year, month, day] = value.split('-').map(Number)
+  const date = new Date(Date.UTC(year, month - 1, day))
+
+  return date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+}
+
+/**
+ * Validates lecturer availability settings submitted from the profile form.
+ * @param {Array<object>} weeklyAvailability - Weekly availability entries.
+ * @param {Array<string>} exceptionDates - Specific unavailable dates.
+ * @returns {{isValid: boolean, error: string}} Validation result.
+ */
+const validateAvailabilitySettings = function (weeklyAvailability, exceptionDates) {
+  for (const entry of weeklyAvailability) {
+    if (!TIME_PATTERN.test(entry.startTime) || !TIME_PATTERN.test(entry.endTime)) {
+      return { isValid: false, error: 'Please enter a valid start and end time for each available weekday.' }
+    }
+
+    if (entry.startTime >= entry.endTime) {
+      return { isValid: false, error: `Start time must be earlier than end time for ${entry.day}.` }
+    }
+  }
+
+  for (const exceptionDate of exceptionDates) {
+    if (!isValidIsoDate(exceptionDate)) {
+      return { isValid: false, error: 'Use valid dates in YYYY-MM-DD format for unavailable dates.' }
+    }
+  }
+
+  return { isValid: true, error: '' }
 }
 
 /**
@@ -88,6 +203,8 @@ const handleConsultationPreferences = async function (req, res, viewer, profileU
   const maxStudents = parseInt(req.body.maxStudents, 10)
   const duration = parseInt(req.body.duration, 10)
   const dailyMax = parseInt(req.body.dailyMax, 10)
+  const weeklyAvailability = buildWeeklyAvailability(req.body)
+  const exceptionDates = parseExceptionDates(getTrimmedField(req.body, 'exceptionDates'))
 
   if (isNaN(minStudents) || isNaN(maxStudents) || isNaN(duration) || isNaN(dailyMax)) {
     const error = 'Please enter valid numbers for all consultation settings.'
@@ -115,6 +232,7 @@ const handleConsultationPreferences = async function (req, res, viewer, profileU
     }
 
     const validation = validateConsultationPreferences({ minStudents, maxStudents, duration, dailyMax })
+    const availabilityValidation = validateAvailabilitySettings(weeklyAvailability, exceptionDates)
 
     if (!validation.isValid) {
       if (isAjax) return res.status(400).json({ success: false, error: validation.error })
@@ -129,7 +247,27 @@ const handleConsultationPreferences = async function (req, res, viewer, profileU
       })
     }
 
-    await setLecturerAvailability(resolvedUsername, { minStudents, maxStudents, duration, dailyMax })
+    if (!availabilityValidation.isValid) {
+      if (isAjax) return res.status(400).json({ success: false, error: availabilityValidation.error })
+      return renderProfile(res, {
+        statusCode: 400,
+        ...buildProfileViewState(user, {
+          canEdit: true,
+          username: resolvedUsername,
+          consultationPreferences: { minStudents, maxStudents, duration, dailyMax, weeklyAvailability, exceptionDates },
+          prefError: availabilityValidation.error
+        })
+      })
+    }
+
+    await setLecturerAvailability(resolvedUsername, {
+      minStudents,
+      maxStudents,
+      duration,
+      dailyMax,
+      weeklyAvailability,
+      exceptionDates
+    })
     if (isAjax) return res.json({ success: true })
     return res.redirect(`/user_profile?user=${encodeURIComponent(resolvedUsername)}`)
   } catch {

--- a/src/utils/calendar.js
+++ b/src/utils/calendar.js
@@ -1,4 +1,5 @@
 const DAY_LABELS = Object.freeze(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'])
+const WEEKDAY_KEYS = Object.freeze(['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'])
 const MONTH_LABELS = Object.freeze([
   'January',
   'February',
@@ -15,26 +16,113 @@ const MONTH_LABELS = Object.freeze([
 ])
 
 /**
+ * Builds a YYYY-MM-DD date string.
+ * @param {number} year - Four-digit year.
+ * @param {number} month - Zero-based month index.
+ * @param {number} dayNumber - Day number in the month.
+ * @returns {string} ISO date string.
+ */
+const buildIsoDate = function (year, month, dayNumber) {
+  return `${year}-${String(month + 1).padStart(2, '0')}-${String(dayNumber).padStart(2, '0')}`
+}
+
+/**
+ * Builds a calendar cell for an empty day slot.
+ * @returns {{dayNumber: string, isoDate: string, isEmpty: boolean, availabilityState: string, availabilityText: string}} Empty calendar cell.
+ */
+const buildEmptyCalendarCell = function () {
+  return {
+    dayNumber: '',
+    isoDate: '',
+    isEmpty: true,
+    availabilityState: 'empty',
+    availabilityText: ''
+  }
+}
+
+/**
+ * Builds a calendar cell for a real day in the current month.
+ * @param {number} year - Four-digit year.
+ * @param {number} month - Zero-based month index.
+ * @param {number} dayNumber - Day number in the month.
+ * @param {Record<string, {startTime?: string, endTime?: string}>} weeklyAvailabilityByDay - Availability entries keyed by weekday.
+ * @param {Set<string>} exceptionDateSet - Set of unavailable ISO date strings.
+ * @returns {{dayNumber: number, isoDate: string, isEmpty: boolean, availabilityState: string, availabilityText: string}} Calendar cell.
+ */
+const buildCalendarDayCell = function (year, month, dayNumber, weeklyAvailabilityByDay, exceptionDateSet) {
+  const isoDate = buildIsoDate(year, month, dayNumber)
+
+  if (exceptionDateSet.has(isoDate)) {
+    return {
+      dayNumber,
+      isoDate,
+      isEmpty: false,
+      availabilityState: 'unavailable',
+      availabilityText: 'Unavailable'
+    }
+  }
+
+  const weekday = WEEKDAY_KEYS[new Date(year, month, dayNumber).getDay()]
+  const weeklyAvailability = weeklyAvailabilityByDay[weekday]
+
+  if (!weeklyAvailability) {
+    return {
+      dayNumber,
+      isoDate,
+      isEmpty: false,
+      availabilityState: 'none',
+      availabilityText: ''
+    }
+  }
+
+  const hasTimes = weeklyAvailability.startTime && weeklyAvailability.endTime
+
+  return {
+    dayNumber,
+    isoDate,
+    isEmpty: false,
+    availabilityState: 'available',
+    availabilityText: hasTimes ? `${weeklyAvailability.startTime} - ${weeklyAvailability.endTime}` : 'Available'
+  }
+}
+
+/**
  * Builds the current month's calendar data.
  * @param {Date} [referenceDate=new Date()] - Date used to choose the displayed month.
- * @returns {{dayLabels: string[], monthLabel: string, weeks: Array<Array<number|string>>}} Calendar view data.
+ * @param {object|null} [availabilityPreferences=null] - Lecturer availability preferences.
+ * @returns {{dayLabels: string[], monthLabel: string, weeks: Array<Array<object>>}} Calendar view data.
  */
-const buildCurrentMonthCalendar = function (referenceDate = new Date()) {
+const buildCurrentMonthCalendar = function (referenceDate = new Date(), availabilityPreferences = null) {
   const year = referenceDate.getFullYear()
   const month = referenceDate.getMonth()
   const firstDayIndex = new Date(year, month, 1).getDay()
   const daysInMonth = new Date(year, month + 1, 0).getDate()
+  const weeklyAvailabilityByDay = {}
+  const weeklyAvailability = Array.isArray(availabilityPreferences?.weeklyAvailability)
+    ? availabilityPreferences.weeklyAvailability
+    : []
+  const exceptionDateSet = new Set(Array.isArray(availabilityPreferences?.exceptionDates)
+    ? availabilityPreferences.exceptionDates
+    : [])
   const weeks = []
   let dayNumber = 1
+
+  weeklyAvailability.forEach(function (entry) {
+    if (!entry || typeof entry.day !== 'string') {
+      return
+    }
+
+    weeklyAvailabilityByDay[entry.day] = entry
+  })
 
   while (dayNumber <= daysInMonth) {
     const week = []
 
     for (let dayIndex = 0; dayIndex < DAY_LABELS.length; dayIndex++) {
       if ((weeks.length === 0 && dayIndex < firstDayIndex) || dayNumber > daysInMonth) {
-        week.push('')
+        week.push(buildEmptyCalendarCell())
       } else {
-        week.push(dayNumber)
+        week.push(buildCalendarDayCell(year, month, dayNumber, weeklyAvailabilityByDay, exceptionDateSet))
         dayNumber += 1
       }
     }

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -48,11 +48,18 @@
           </tr>
         </thead>
         <tbody>
-          <% calendar.weeks.forEach((week) => { %>
+          <% calendar.weeks.forEach(function (week) { %>
             <tr>
-              <% week.forEach((dayNumber) => { %>
-                <% if (dayNumber) { %>
-                  <td class="calendar_day"><%= dayNumber %></td>
+              <% week.forEach(function (day) { %>
+                <% if (!day.isEmpty) { %>
+                  <td class="calendar_day<%= day.availabilityState === 'available' ? ' calendar_day_available' : '' %><%= day.availabilityState === 'unavailable' ? ' calendar_day_unavailable' : '' %>">
+                    <div class="calendar_day_content">
+                      <span class="calendar_day_number"><%= day.dayNumber %></span>
+                      <% if (day.availabilityText) { %>
+                        <span class="calendar_day_note"><%= day.availabilityText %></span>
+                      <% } %>
+                    </div>
+                  </td>
                 <% } else { %>
                   <td class="calendar_day calendar_day_empty"></td>
                 <% } %>

--- a/src/views/user_profile.ejs
+++ b/src/views/user_profile.ejs
@@ -114,10 +114,27 @@
     </section>
 
     <% if (role === 'lecturer') { %>
+    <%
+      const weeklyAvailability = consultationPreferences && consultationPreferences.weeklyAvailability
+        ? consultationPreferences.weeklyAvailability
+        : []
+      const exceptionDates = consultationPreferences && consultationPreferences.exceptionDates
+        ? consultationPreferences.exceptionDates
+        : []
+      const formatDayLabel = function (day) {
+        return `${day.charAt(0).toUpperCase()}${day.slice(1)}`
+      }
+      const weeklyAvailabilityText = weeklyAvailability.length
+        ? weeklyAvailability.map(function (entry) {
+            return `${formatDayLabel(entry.day)}: ${entry.startTime} - ${entry.endTime}`
+          }).join(', ')
+        : 'Not set'
+      const exceptionDatesText = exceptionDates.length ? exceptionDates.join(', ') : 'Not set'
+    %>
     <section class="consultation_preferences_section">
       <h2 class="consultation_preferences_title">Consultation Preferences</h2>
 
-      <div class="error consult_pref_error_container" hidden></div>
+      <div class="error consult_pref_error_container"<%= prefError ? '' : ' hidden' %>><%= prefError %></div>
       <div class="success consult_pref_success_container" hidden>Consultation preferences saved successfully.</div>
 
       <% if (canEdit) { %>
@@ -176,6 +193,49 @@
           </label>
         </div>
 
+        <h3>Availability Settings</h3>
+
+        <% weekdays.forEach(function (day) { %>
+          <% const selectedAvailability = weeklyAvailability.find(function (entry) { return entry.day === day }) %>
+          <div class="consult_flex">
+            <label class="consult_input">
+              <%= formatDayLabel(day) %>
+              <select name="availability_<%= day %>">
+                <option value="unavailable"<%= selectedAvailability ? '' : ' selected' %>>Unavailable</option>
+                <option value="available"<%= selectedAvailability ? ' selected' : '' %>>Available</option>
+              </select>
+            </label>
+
+            <label class="consult_input">
+              Start Time
+              <input
+                type="time"
+                name="start_time_<%= day %>"
+                value="<%= selectedAvailability ? selectedAvailability.startTime : '' %>"
+              >
+            </label>
+
+            <label class="consult_input">
+              End Time
+              <input
+                type="time"
+                name="end_time_<%= day %>"
+                value="<%= selectedAvailability ? selectedAvailability.endTime : '' %>"
+              >
+            </label>
+          </div>
+        <% }) %>
+
+        <label class="consult_input">
+          Unavailable Dates
+          <textarea
+            class="consult_textarea"
+            name="exceptionDates"
+            rows="4"
+            placeholder="YYYY-MM-DD"
+          ><%= exceptionDates.join('\n') %></textarea>
+        </label>
+
         <button type="submit">Save Consultation Preferences</button>
       </form>
       <% } else { %>
@@ -195,6 +255,14 @@
         <div class="profile_detail">
           <h3 class="profile_detail_label">Daily Maximum Consultations</h3>
           <p class="profile_detail_value"><%= consultationPreferences ? consultationPreferences.dailyMax : 'Not set' %></p>
+        </div>
+        <div class="profile_detail">
+          <h3 class="profile_detail_label">Weekly Availability</h3>
+          <p class="profile_detail_value"><%= weeklyAvailabilityText %></p>
+        </div>
+        <div class="profile_detail">
+          <h3 class="profile_detail_label">Unavailable Dates</h3>
+          <p class="profile_detail_value"><%= exceptionDatesText %></p>
         </div>
       </div>
       <% } %>

--- a/tests/models/lecturer_availability_db.test.js
+++ b/tests/models/lecturer_availability_db.test.js
@@ -48,4 +48,52 @@ describe('lecturer availability database operations', () => {
       { upsert: true }
     )
   })
+
+  test('setLecturerAvailability upserts weekly availability and exception dates when provided', async function () {
+    mockCollection.updateOne.mockResolvedValue({ acknowledged: true })
+
+    await setLecturerAvailability('dr_jones', {
+      weeklyAvailability: [
+        { day: 'monday', startTime: '09:00', endTime: '12:00' },
+        { day: 'wednesday', startTime: '13:00', endTime: '16:00' }
+      ],
+      exceptionDates: ['2026-05-01', '2026-05-08']
+    })
+
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      { username: 'dr_jones' },
+      {
+        $set: {
+          username: 'dr_jones',
+          weeklyAvailability: [
+            { day: 'monday', startTime: '09:00', endTime: '12:00' },
+            { day: 'wednesday', startTime: '13:00', endTime: '16:00' }
+          ],
+          exceptionDates: ['2026-05-01', '2026-05-08']
+        }
+      },
+      { upsert: true }
+    )
+  })
+
+  test('setLecturerAvailability only sets the fields that are provided', async function () {
+    mockCollection.updateOne.mockResolvedValue({ acknowledged: true })
+
+    await setLecturerAvailability('dr_jones', {
+      duration: 45,
+      weeklyAvailability: [{ day: 'friday', startTime: '10:00', endTime: '11:00' }]
+    })
+
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      { username: 'dr_jones' },
+      {
+        $set: {
+          username: 'dr_jones',
+          duration: 45,
+          weeklyAvailability: [{ day: 'friday', startTime: '10:00', endTime: '11:00' }]
+        }
+      },
+      { upsert: true }
+    )
+  })
 })

--- a/tests/routes/home.test.js
+++ b/tests/routes/home.test.js
@@ -7,6 +7,10 @@ jest.mock('../../src/models/db', () => ({
   getMongoUri: jest.fn()
 }))
 
+jest.mock('../../src/models/lecturer_availability_db', () => ({
+  getLecturerAvailability: jest.fn()
+}))
+
 jest.mock('../../src/models/user_db', () => ({
   addUser: jest.fn(),
   deleteUser: jest.fn(),
@@ -17,6 +21,7 @@ jest.mock('../../src/models/user_db', () => ({
 const http = require('node:http')
 
 const { connectToDatabase } = require('../../src/models/db')
+const { getLecturerAvailability } = require('../../src/models/lecturer_availability_db')
 const { getUser, searchLecturers } = require('../../src/models/user_db')
 const { hashPassword } = require('../../src/utils/password')
 const app = require('../../src/app')
@@ -96,6 +101,16 @@ const getCurrentMonthLabel = function (referenceDate = new Date()) {
   return `${MONTH_LABELS[referenceDate.getMonth()]} ${referenceDate.getFullYear()}`
 }
 
+/**
+ * Returns a YYYY-MM-DD string for the current month.
+ * @param {number} dayNumber - Day number in the current month.
+ * @param {Date} [referenceDate=new Date()] - Date used to choose the month.
+ * @returns {string} ISO date string.
+ */
+const getCurrentMonthDate = function (dayNumber, referenceDate = new Date()) {
+  return `${referenceDate.getFullYear()}-${String(referenceDate.getMonth() + 1).padStart(2, '0')}-${String(dayNumber).padStart(2, '0')}`
+}
+
 describe('home route', () => {
   let server
 
@@ -125,6 +140,7 @@ describe('home route', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     connectToDatabase.mockResolvedValue(undefined)
+    getLecturerAvailability.mockResolvedValue(null)
     searchLecturers.mockResolvedValue([])
   })
 
@@ -167,6 +183,7 @@ describe('home route', () => {
     expect(body).toContain('calendar_table')
     expect(body).toContain('Sun')
     expect(body).toContain('Sat')
+    expect(getLecturerAvailability).not.toHaveBeenCalled()
   })
 
   test('Renders the lecturer home page after a successful login', async () => {
@@ -197,6 +214,31 @@ describe('home route', () => {
     expect(body).not.toContain('Schedule a Consultation')
     expect(body).toContain(currentMonthLabel)
     expect(body).toContain('calendar_table')
+  })
+
+  test('Highlights lecturer availability on the home calendar', async () => {
+    const { sessionCookie } = await loginAs({
+      role: 'lecturer',
+      username: 'lecturer1'
+    })
+    getLecturerAvailability.mockResolvedValue({
+      weeklyAvailability: [{ day: 'monday', startTime: '09:00', endTime: '12:00' }],
+      exceptionDates: [getCurrentMonthDate(1)]
+    })
+
+    const response = await fetch(`${baseUrl}/home`, {
+      headers: {
+        cookie: sessionCookie
+      }
+    })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(getLecturerAvailability).toHaveBeenCalledWith('lecturer1')
+    expect(body).toContain('calendar_day_available')
+    expect(body).toContain('calendar_day_unavailable')
+    expect(body).toContain('09:00 - 12:00')
+    expect(body).toContain('Unavailable')
   })
 
   test('Redirects unauthenticated users to login when requesting the schedule consultation page', async () => {

--- a/tests/routes/user_profile.test.js
+++ b/tests/routes/user_profile.test.js
@@ -320,7 +320,14 @@ describe('user profile route', () => {
   test('Renders the consultation preferences form when a lecturer views their own profile', async () => {
     const sessionCookie = await loginAs({ role: 'lecturer', username: 'dr_jones' })
     getUser.mockResolvedValueOnce(await buildUser({ role: 'lecturer', username: 'dr_jones' }))
-    getLecturerAvailability.mockResolvedValueOnce({ minStudents: 2, maxStudents: 10, duration: 60, dailyMax: 4 })
+    getLecturerAvailability.mockResolvedValueOnce({
+      minStudents: 2,
+      maxStudents: 10,
+      duration: 60,
+      dailyMax: 4,
+      weeklyAvailability: [{ day: 'monday', startTime: '09:00', endTime: '12:00' }],
+      exceptionDates: ['2026-05-01']
+    })
 
     const response = await fetch(`${baseUrl}/user_profile?user=dr_jones`, {
       headers: { cookie: sessionCookie }
@@ -330,13 +337,23 @@ describe('user profile route', () => {
     expect(response.status).toBe(200)
     expect(getLecturerAvailability).toHaveBeenCalledWith('dr_jones')
     expect(body).toContain('Consultation Preferences')
+    expect(body).toContain('Availability Settings')
+    expect(body).toContain('name="availability_monday"')
+    expect(body).toContain('2026-05-01')
     expect(body).toContain('Save Consultation Preferences')
   })
 
   test('Renders read-only consultation preferences when a student views a lecturer profile', async () => {
     const sessionCookie = await loginAs()
     getUser.mockResolvedValueOnce(await buildUser({ role: 'lecturer', username: 'dr_jones', email: 'dr@example.com' }))
-    getLecturerAvailability.mockResolvedValueOnce({ minStudents: 2, maxStudents: 10, duration: 60, dailyMax: 4 })
+    getLecturerAvailability.mockResolvedValueOnce({
+      minStudents: 2,
+      maxStudents: 10,
+      duration: 60,
+      dailyMax: 4,
+      weeklyAvailability: [{ day: 'monday', startTime: '09:00', endTime: '12:00' }],
+      exceptionDates: ['2026-05-01']
+    })
 
     const response = await fetch(`${baseUrl}/user_profile?user=dr_jones`, {
       headers: { cookie: sessionCookie }
@@ -346,6 +363,9 @@ describe('user profile route', () => {
     expect(response.status).toBe(200)
     expect(getLecturerAvailability).toHaveBeenCalledWith('dr_jones')
     expect(body).toContain('Consultation Preferences')
+    expect(body).toContain('Weekly Availability')
+    expect(body).toContain('Monday: 09:00 - 12:00')
+    expect(body).toContain('2026-05-01')
     expect(body).not.toContain('Save Consultation Preferences')
   })
 
@@ -373,13 +393,61 @@ describe('user profile route', () => {
         'x-requested-with': 'XMLHttpRequest',
         cookie: sessionCookie
       },
-      body: encodeForm({ formType: 'consultationPreferences', username: 'dr_jones', minStudents: '2', maxStudents: '10', duration: '60', dailyMax: '4' })
+      body: encodeForm({
+        formType: 'consultationPreferences',
+        username: 'dr_jones',
+        minStudents: '2',
+        maxStudents: '10',
+        duration: '60',
+        dailyMax: '4',
+        availability_monday: 'available',
+        start_time_monday: '09:00',
+        end_time_monday: '12:00',
+        exceptionDates: '2026-05-01\n2026-05-02'
+      })
     })
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(setLecturerAvailability).toHaveBeenCalledWith('dr_jones', { minStudents: 2, maxStudents: 10, duration: 60, dailyMax: 4 })
+    expect(setLecturerAvailability).toHaveBeenCalledWith('dr_jones', {
+      minStudents: 2,
+      maxStudents: 10,
+      duration: 60,
+      dailyMax: 4,
+      weeklyAvailability: [{ day: 'monday', startTime: '09:00', endTime: '12:00' }],
+      exceptionDates: ['2026-05-01', '2026-05-02']
+    })
     expect(data).toEqual({ success: true })
+  })
+
+  test('Returns a JSON error when an available weekday has an invalid time range', async () => {
+    const sessionCookie = await loginAs({ role: 'lecturer', username: 'dr_jones' })
+    getUser.mockResolvedValueOnce(await buildUser({ role: 'lecturer', username: 'dr_jones' }))
+
+    const response = await fetch(`${baseUrl}/user_profile`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-requested-with': 'XMLHttpRequest',
+        cookie: sessionCookie
+      },
+      body: encodeForm({
+        formType: 'consultationPreferences',
+        username: 'dr_jones',
+        minStudents: '2',
+        maxStudents: '10',
+        duration: '60',
+        dailyMax: '4',
+        availability_monday: 'available',
+        start_time_monday: '12:00',
+        end_time_monday: '09:00'
+      })
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(setLecturerAvailability).not.toHaveBeenCalled()
+    expect(data).toEqual({ success: false, error: 'Start time must be earlier than end time for monday.' })
   })
 
   test('Returns a JSON error when a consultation preference value is negative', async () => {

--- a/tests/utils/calendar.test.js
+++ b/tests/utils/calendar.test.js
@@ -1,0 +1,73 @@
+const { buildCurrentMonthCalendar } = require('../../src/utils/calendar')
+
+/**
+ * Finds the first day number in a month for the given weekday.
+ * @param {number} year - Four-digit year.
+ * @param {number} month - Zero-based month index.
+ * @param {number} weekdayIndex - Sunday-based weekday index.
+ * @returns {number} First matching day number.
+ */
+const findFirstDayNumberForWeekday = function (year, month, weekdayIndex) {
+  let dayNumber = 1
+
+  while (new Date(year, month, dayNumber).getMonth() === month) {
+    if (new Date(year, month, dayNumber).getDay() === weekdayIndex) {
+      return dayNumber
+    }
+
+    dayNumber += 1
+  }
+
+  return -1
+}
+
+/**
+ * Builds a YYYY-MM-DD date string.
+ * @param {number} year - Four-digit year.
+ * @param {number} month - Zero-based month index.
+ * @param {number} dayNumber - Day number in the month.
+ * @returns {string} ISO date string.
+ */
+const buildIsoDate = function (year, month, dayNumber) {
+  return `${year}-${String(month + 1).padStart(2, '0')}-${String(dayNumber).padStart(2, '0')}`
+}
+
+const findCalendarDay = function (calendar, dayNumber) {
+  return calendar.weeks.flat().find(function (day) {
+    return day.dayNumber === dayNumber
+  })
+}
+
+describe('calendar utility', () => {
+  test('marks weekly availability days as available', function () {
+    const year = 2026
+    const month = 4
+    const firstMonday = findFirstDayNumberForWeekday(year, month, 1)
+    const calendar = buildCurrentMonthCalendar(new Date(year, month, 15), {
+      weeklyAvailability: [{ day: 'monday', startTime: '09:00', endTime: '12:00' }],
+      exceptionDates: []
+    })
+
+    expect(findCalendarDay(calendar, firstMonday)).toEqual(expect.objectContaining({
+      dayNumber: firstMonday,
+      availabilityState: 'available',
+      availabilityText: '09:00 - 12:00'
+    }))
+  })
+
+  test('marks exception dates as unavailable even when the weekday is usually available', function () {
+    const year = 2026
+    const month = 4
+    const firstMonday = findFirstDayNumberForWeekday(year, month, 1)
+    const calendar = buildCurrentMonthCalendar(new Date(year, month, 15), {
+      weeklyAvailability: [{ day: 'monday', startTime: '09:00', endTime: '12:00' }],
+      exceptionDates: [buildIsoDate(year, month, firstMonday)]
+    })
+
+    expect(findCalendarDay(calendar, firstMonday)).toEqual(expect.objectContaining({
+      dayNumber: firstMonday,
+      availabilityState: 'unavailable',
+      availabilityText: 'Unavailable'
+    }))
+  })
+})


### PR DESCRIPTION
Closes #4 

Summary:

This PR adds a simple lecturer availability workflow so lecturers can save weekly availability and specific unavailable dates, view those preferences on their profile, and see them highlighted on the home page calendar.

Changes:

- extend lecturer availability persistence to store weekly day/time slots and non-repeating unavailable dates
- add lecturer availability settings to the lecturer user profile page
- validate and save availability through the existing profile route
- show saved availability preferences on the lecturer profile page
- highlight available and unavailable days on the lecturer home page calendar
- add model, route, and calendar utility tests for the new behaviour

Testing:

- ran `npm test -- --runInBand`
- ran `npm run lint`
- manually verified the lecturer flow by:
  - registering and logging in as a lecturer
  - saving weekly availability and an unavailable date
  - confirming the profile page showed the saved preferences
  - confirming the home calendar showed available days and the unavailable exception date

Notes

- kept the first implementation simple by using `YYYY-MM-DD` input for specific unavailable dates
- current calendar highlighting is shown on the lecturer home page for the current month