### PR TITLE
Find consultation

### DIFF
--- a/src/models/consultation_db.js
+++ b/src/models/consultation_db.js
@@ -57,9 +57,19 @@ const listConsultationsForLecturerOnDate = async function (lecturerId, isoDate) 
  * @returns {Promise<Array<object>>} Matching consultations enriched for display.
  */
 const searchConsultationsForStudent = async function ({
-  username = ''
+  username = '',
+  lecturerId = '',
+  date = '',
+  time = ''
 } = {}) {
-  const consultations = await consultationsCollection().find({}).toArray()
+  const query = {}
+  if (lecturerId) query.lecturerId = lecturerId
+  if (date && time) {
+    query.datetime = `${date}T${time}`
+  } else if (date) {
+    query.datetime = { $gte: `${date}T00:00`, $lt: `${date}T23:59~` }
+  }
+  const consultations = await consultationsCollection().find(query).toArray()
 
   if (consultations.length === 0) {
     return []

--- a/src/models/consultation_db.js
+++ b/src/models/consultation_db.js
@@ -54,6 +54,9 @@ const listConsultationsForLecturerOnDate = async function (lecturerId, isoDate) 
  * Searches consultations for display on the join page.
  * @param {object} options - Search options.
  * @param {string} [options.username=''] - Current student username.
+ * @param {string} [options.lecturerId=''] - Filter by lecturer username.
+ * @param {string} [options.date=''] - Filter by date in YYYY-MM-DD format.
+ * @param {string} [options.time=''] - Filter by exact start time in HH:MM format; requires date.
  * @returns {Promise<Array<object>>} Matching consultations enriched for display.
  */
 const searchConsultationsForStudent = async function ({

--- a/src/public/scripts/join_consultation_search.js
+++ b/src/public/scripts/join_consultation_search.js
@@ -5,6 +5,11 @@ document.addEventListener('DOMContentLoaded', function () {
   const dateInput = document.getElementById('filter_date')
   const timeInput = document.getElementById('filter_time')
 
+  /**
+   * Constrains the time input's minimum value to the current time when today's date is selected.
+   * Clears any previously entered time that would now fall in the past.
+   * Removes the constraint when a future date is selected.
+   */
   const updateTimeMin = function () {
     if (!dateInput || !timeInput) return
     const today = new Date().toISOString().slice(0, 10)

--- a/src/public/scripts/join_consultation_search.js
+++ b/src/public/scripts/join_consultation_search.js
@@ -2,6 +2,27 @@ document.addEventListener('DOMContentLoaded', function () {
   const JOIN_ERROR = 'Unable to join consultation right now.'
   const feedback = document.getElementById('join_consultation_feedback')
   const resultsSection = document.getElementById('join_consultation_results')
+  const dateInput = document.getElementById('filter_date')
+  const timeInput = document.getElementById('filter_time')
+
+  const updateTimeMin = function () {
+    if (!dateInput || !timeInput) return
+    const today = new Date().toISOString().slice(0, 10)
+    if (dateInput.value === today) {
+      const now = new Date()
+      const hh = String(now.getHours()).padStart(2, '0')
+      const mm = String(now.getMinutes()).padStart(2, '0')
+      timeInput.min = `${hh}:${mm}`
+      if (timeInput.value && timeInput.value < timeInput.min) {
+        timeInput.value = ''
+      }
+    } else {
+      timeInput.min = ''
+    }
+  }
+
+  if (dateInput) dateInput.addEventListener('change', updateTimeMin)
+  updateTimeMin()
 
   if (!feedback || !resultsSection) {
     return

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -366,6 +366,12 @@ a {
   opacity: 0.65;
 }
 
+.button_compact {
+  padding: 12px 10px;
+  margin-left: 24px;
+  vertical-align: middle;
+}
+
 .is_hidden {
   display: none;
 }

--- a/src/routes/consultations.js
+++ b/src/routes/consultations.js
@@ -144,12 +144,19 @@ router.get('/new', async function (req, res) {
     })
   }
 
+  const prefilledLecturerId = (req.query.lecturerId || '').trim()
+  const prefilledDate = (req.query.date || '').trim()
+  const prefilledTime = (req.query.time || '').trim()
+  const selectedDatetime = prefilledDate ? `${prefilledDate}T${prefilledTime || '09:00'}` : ''
+
   try {
     await connectToDatabase()
     const lecturers = await loadLecturerOptions(universityId)
 
     return renderCreateConsultation(res, {
       lecturers,
+      selectedDatetime,
+      selectedLecturerId: prefilledLecturerId,
       username
     })
   } catch {

--- a/src/routes/join_consultation.js
+++ b/src/routes/join_consultation.js
@@ -1,6 +1,9 @@
 const express = require('express')
 const { connectToDatabase } = require('../models/db')
 const { addStudentToConsultation, JOIN_RESULT_REASONS, searchConsultationsForStudent } = require('../models/consultation_db')
+const { getLecturerAvailability } = require('../models/lecturer_availability_db')
+const { searchLecturers } = require('../models/user_db')
+const { isDateAvailableForLecturer } = require('../services/consultation_availability_validation')
 
 const LOAD_ERROR = 'Unable to load join consultations right now.'
 const JOIN_ERROR = 'Unable to join consultation right now.'
@@ -12,24 +15,69 @@ const JOIN_ERROR_MESSAGES = {
 
 const router = express.Router()
 
+const buildLecturerOptions = function (lecturers = []) {
+  return lecturers.map(function (lecturer) {
+    const fullName = `${lecturer.firstName || ''} ${lecturer.lastName || ''}`.trim()
+    return {
+      id: lecturer.username || '',
+      name: fullName || lecturer.username || 'Unknown lecturer'
+    }
+  })
+}
+
 const renderJoinConsultation = function (res, {
   consultations = [],
+  createLink = '',
+  emptyStateType = '',
   error = '',
+  filters = { lecturerId: '', date: '', time: '' },
+  lecturers = [],
   statusCode = 200
 } = {}) {
   return res.status(statusCode).render('join_consultation', {
     consultations,
-    error
+    createLink,
+    emptyStateType,
+    error,
+    filters,
+    lecturers
   })
 }
 
 router.get('/', async function (req, res) {
-  const { username = '' } = req.session?.user || {}
+  const { username = '', universityId = '', facultyId = '', schoolId = '' } = req.session?.user || {}
+  const lecturerId = (req.query.lecturerId || '').trim()
+  const date = (req.query.date || '').trim()
+  const time = (req.query.time || '').trim()
 
   try {
     await connectToDatabase()
+    const [consultations, lecturerDocs] = await Promise.all([
+      searchConsultationsForStudent({ username, lecturerId, date, time }),
+      searchLecturers({ universityId, facultyId, schoolId })
+    ])
+    const lecturers = buildLecturerOptions(lecturerDocs)
+
+    let emptyStateType = ''
+    let createLink = ''
+
+    if (consultations.length === 0 && lecturerId && date) {
+      const availability = await getLecturerAvailability(lecturerId)
+      if (isDateAvailableForLecturer(availability, date, time)) {
+        emptyStateType = 'create'
+        const timeParam = time ? `&time=${encodeURIComponent(time)}` : ''
+        createLink = `/consultations/new?lecturerId=${encodeURIComponent(lecturerId)}&date=${encodeURIComponent(date)}${timeParam}`
+      } else {
+        emptyStateType = 'violation'
+      }
+    }
+
     return renderJoinConsultation(res, {
-      consultations: await searchConsultationsForStudent({ username })
+      consultations,
+      createLink,
+      emptyStateType,
+      filters: { lecturerId, date, time },
+      lecturers
     })
   } catch {
     return renderJoinConsultation(res, { error: LOAD_ERROR, statusCode: 500 })

--- a/src/routes/join_consultation.js
+++ b/src/routes/join_consultation.js
@@ -15,6 +15,11 @@ const JOIN_ERROR_MESSAGES = {
 
 const router = express.Router()
 
+/**
+ * Converts lecturer documents into option objects for the consultation search form.
+ * @param {Array<object>} lecturers - Lecturer documents from the database.
+ * @returns {Array<{id: string, name: string}>} Lecturer options for the dropdown.
+ */
 const buildLecturerOptions = function (lecturers = []) {
   return lecturers.map(function (lecturer) {
     const fullName = `${lecturer.firstName || ''} ${lecturer.lastName || ''}`.trim()
@@ -25,6 +30,19 @@ const buildLecturerOptions = function (lecturers = []) {
   })
 }
 
+/**
+ * Renders the join consultation page.
+ * @param {import('express').Response} res - Express response object.
+ * @param {object} [options] - View data.
+ * @param {Array<object>} [options.consultations=[]] - Enriched consultation objects for display.
+ * @param {string} [options.createLink=''] - Pre-filled URL to the create consultation form.
+ * @param {string} [options.emptyStateType=''] - Empty state variant: 'create', 'violation', or ''.
+ * @param {string} [options.error=''] - Error message to display.
+ * @param {object} [options.filters] - Active search filter values.
+ * @param {Array<object>} [options.lecturers=[]] - Lecturer options for the dropdown.
+ * @param {number} [options.statusCode=200] - HTTP status code.
+ * @returns {import('express').Response} The rendered response.
+ */
 const renderJoinConsultation = function (res, {
   consultations = [],
   createLink = '',

--- a/src/services/consultation_availability_validation.js
+++ b/src/services/consultation_availability_validation.js
@@ -151,8 +151,30 @@ const findOverlappingConsultation = function ({ scheduledConsultations = [], pro
   return null
 }
 
+const isDateAvailableForLecturer = function (availability, date, time) {
+  if (!availability) return false
+  if (Array.isArray(availability.exceptionDates) && availability.exceptionDates.includes(date)) return false
+  const weekday = getWeekdayFromIso(date)
+  if (!weekday) return false
+  const weeklyAvailability = Array.isArray(availability.weeklyAvailability) ? availability.weeklyAvailability : []
+  const matchingSlot = weeklyAvailability.find(function (slot) {
+    return slot && typeof slot === 'object' && (slot.day || '').toLowerCase() === weekday
+  })
+  if (!matchingSlot) return false
+  if (!TIME_PATTERN.test(time) || !TIME_PATTERN.test(matchingSlot.startTime) || !TIME_PATTERN.test(matchingSlot.endTime)) {
+    return true
+  }
+  const duration = Number.isInteger(availability.duration) ? availability.duration : 60
+  const consultationEnd = addMinutesToTime(time, duration)
+  if (!consultationEnd) return false
+  return timeToMinutes(time) >= timeToMinutes(matchingSlot.startTime) &&
+    timeToMinutes(consultationEnd) <= timeToMinutes(matchingSlot.endTime)
+}
+
 module.exports = {
   addMinutesToTime,
-  validateLecturerAvailability,
-  findOverlappingConsultation
+  findOverlappingConsultation,
+  getWeekdayFromIso,
+  isDateAvailableForLecturer,
+  validateLecturerAvailability
 }

--- a/src/services/consultation_availability_validation.js
+++ b/src/services/consultation_availability_validation.js
@@ -151,6 +151,16 @@ const findOverlappingConsultation = function ({ scheduledConsultations = [], pro
   return null
 }
 
+/**
+ * Checks whether a given date and optional start time fall within a lecturer's availability.
+ * When no valid time is provided the check is date-only: any date with a matching weekly slot passes.
+ * When a valid time is provided it verifies that a consultation of the lecturer's duration fits
+ * entirely within the slot (i.e. start >= slotStart and start + duration <= slotEnd).
+ * @param {object|null} availability - Lecturer availability document.
+ * @param {string} date - Date to check in YYYY-MM-DD format.
+ * @param {string} time - Proposed start time in HH:MM format, or empty string for a date-only check.
+ * @returns {boolean} True when the date (and time, if provided) is within the lecturer's availability.
+ */
 const isDateAvailableForLecturer = function (availability, date, time) {
   if (!availability) return false
   if (Array.isArray(availability.exceptionDates) && availability.exceptionDates.includes(date)) return false

--- a/src/views/join_consultation.ejs
+++ b/src/views/join_consultation.ejs
@@ -45,8 +45,7 @@
     <section id="join_consultation_results" class="results">
       <% if (consultations.length === 0) { %>
         <% if (emptyStateType === 'create') { %>
-          <p>No matching consultations. Create new consultation?</p>
-          <a href="<%= createLink %>" class="button success">Create Consultation</a>
+          <p>No matching consultations. Create new consultation? <a href="<%= createLink %>" class="button_compact">Create</a></p>
         <% } else if (emptyStateType === 'violation') { %>
           <p>No matching consultation - Violates lecturer preferences.</p>
         <% } else { %>

--- a/src/views/join_consultation.ejs
+++ b/src/views/join_consultation.ejs
@@ -16,11 +16,42 @@
     <% if (error) { %>
       <p class="error"><%= error %></p>
     <% } %>
+
+    <form method="get" action="/join_consultation" class="search_form">
+      <label>
+        Lecturer
+        <select name="lecturerId">
+          <option value="">All lecturers</option>
+          <% lecturers.forEach(function (lecturer) { %>
+            <option value="<%= lecturer.id %>" <%= filters.lecturerId === lecturer.id ? 'selected' : '' %>>
+              <%= lecturer.name %>
+            </option>
+          <% }) %>
+        </select>
+      </label>
+      <label>
+        Date
+        <input type="date" id="filter_date" name="date" value="<%= filters.date %>" min="<%= new Date().toISOString().slice(0, 10) %>">
+      </label>
+      <label>
+        Time
+        <input type="time" id="filter_time" name="time" value="<%= filters.time %>" step="900">
+      </label>
+      <button type="submit">Search</button>
+    </form>
+
     <p id="join_consultation_feedback" class="is_hidden" aria-live="polite"></p>
 
     <section id="join_consultation_results" class="results">
       <% if (consultations.length === 0) { %>
-        <p>No consultations found.</p>
+        <% if (emptyStateType === 'create') { %>
+          <p>No matching consultations. Create new consultation?</p>
+          <a href="<%= createLink %>" class="button success">Create Consultation</a>
+        <% } else if (emptyStateType === 'violation') { %>
+          <p>No matching consultation - Violates lecturer preferences.</p>
+        <% } else { %>
+          <p>No consultations found.</p>
+        <% } %>
       <% } else { %>
         <% consultations.forEach(function (consultation) { %>
           <article class="profile_detail join_consultation_item">

--- a/tests/E2E/join_consultation.js
+++ b/tests/E2E/join_consultation.js
@@ -35,6 +35,45 @@ test.describe('join consultation E2E', () => {
     await closeDatabaseConnection()
   })
 
+  test.describe('search filter and create pre-fill', function () {
+    const FILTER_LECTURER_ID = LECTURER_USERNAME
+    const MONDAY_DATE = '2030-05-06'
+
+    test.beforeEach(async function () {
+      await connectToDatabase()
+      await getCollection('LecturerAvailability').deleteOne({ username: FILTER_LECTURER_ID })
+      await getCollection('LecturerAvailability').insertOne({
+        duration: 60,
+        exceptionDates: [],
+        username: FILTER_LECTURER_ID,
+        weeklyAvailability: [{ day: 'monday', startTime: '08:00', endTime: '12:00' }]
+      })
+    })
+
+    test.afterEach(async function () {
+      await connectToDatabase()
+      await getCollection('LecturerAvailability').deleteOne({ username: FILTER_LECTURER_ID })
+    })
+
+    test('navigating to a valid search shows a create link that pre-fills the consultation form', async ({ page }) => {
+      await page.goto('/login')
+      await page.getByRole('textbox', { name: 'Username' }).fill(STUDENT_USERNAME)
+      await page.getByLabel('Password').fill(PASSWORD)
+      await page.getByRole('button', { name: 'Log In' }).click()
+      await expect(page).toHaveURL(/\/home$/)
+
+      await page.goto(`/join_consultation?lecturerId=${FILTER_LECTURER_ID}&date=${MONDAY_DATE}&time=09%3A00`)
+
+      await expect(page.getByText('No matching consultations')).toBeVisible()
+
+      await page.getByRole('link', { name: 'Create' }).click()
+
+      await expect(page).toHaveURL(/\/consultations\/new/)
+      await expect(page.locator('input[name="datetime"]')).toHaveValue(`${MONDAY_DATE}T09:00`)
+      await expect(page.locator('select[name="lecturerId"]')).toHaveValue(FILTER_LECTURER_ID)
+    })
+  })
+
   test('student can join an open consultation from the home page', async ({ page }) => {
     await connectToDatabase()
     await getCollection('Consultation').insertMany([

--- a/tests/integration/join_consultation.test.js
+++ b/tests/integration/join_consultation.test.js
@@ -2,6 +2,7 @@ const http = require('node:http')
 const { closeDatabaseConnection, connectToDatabase, getCollection } = require('../../src/models/db')
 const { ObjectId } = require('mongodb')
 const app = require('../../src/app')
+const { setLecturerAvailability } = require('../../src/models/lecturer_availability_db')
 
 const LECTURER_USERNAME = 'user1'
 const PASSWORD = 'password'
@@ -12,6 +13,8 @@ const TEST_TITLE_PREFIX = 'join-consultation-integration-'
 const FULL_TITLE = `${TEST_TITLE_PREFIX}full-${TEST_ID}`
 const JOINED_TITLE = `${TEST_TITLE_PREFIX}joined-${TEST_ID}`
 const OPEN_TITLE = `${TEST_TITLE_PREFIX}open-${TEST_ID}`
+const TEST_FILTER_LECTURER_ID = `itestfiltlect${TEST_ID}`
+const MONDAY_DATE = '2030-05-06'
 
 let baseUrl
 let server
@@ -162,6 +165,91 @@ describe('join consultation integration flow', () => {
     expect(body).toContain('Join')
     expect(body).toContain('Closed')
     expect(body).toContain('Joined')
+  })
+
+  describe('filter and empty-state', function () {
+    beforeEach(async function () {
+      if (!process.env.MONGODB_URI) {
+        return
+      }
+
+      await connectToDatabase()
+      await getCollection('LecturerAvailability').deleteOne({ username: TEST_FILTER_LECTURER_ID })
+      await setLecturerAvailability(TEST_FILTER_LECTURER_ID, {
+        duration: 60,
+        exceptionDates: [],
+        weeklyAvailability: [{ day: 'monday', startTime: '08:00', endTime: '12:00' }]
+      })
+    })
+
+    afterEach(async function () {
+      if (!process.env.MONGODB_URI) {
+        return
+      }
+
+      await connectToDatabase()
+      await getCollection('LecturerAvailability').deleteOne({ username: TEST_FILTER_LECTURER_ID })
+    })
+
+    RUN_DB_TEST('filters consultations by lecturerId', async function () {
+      const FILTER_TITLE = `${TEST_TITLE_PREFIX}filter-lecturer-${TEST_ID}`
+      const OTHER_TITLE = `${TEST_TITLE_PREFIX}filter-other-${TEST_ID}`
+
+      await connectToDatabase()
+      await getCollection('Consultation').insertMany([
+        {
+          attendees: [],
+          capacity: 5,
+          datetime: `${MONDAY_DATE}T09:00`,
+          lecturerId: TEST_FILTER_LECTURER_ID,
+          organiserId: STUDENT_USERNAME,
+          title: FILTER_TITLE
+        },
+        {
+          attendees: [],
+          capacity: 5,
+          datetime: `${MONDAY_DATE}T09:00`,
+          lecturerId: LECTURER_USERNAME,
+          organiserId: STUDENT_USERNAME,
+          title: OTHER_TITLE
+        }
+      ])
+
+      const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: STUDENT_USERNAME })
+      const response = await fetch(`${baseUrl}/join_consultation?lecturerId=${TEST_FILTER_LECTURER_ID}`, {
+        headers: { cookie: sessionCookie }
+      })
+      const body = await response.text()
+
+      expect(response.status).toBe(200)
+      expect(body).toContain(FILTER_TITLE)
+      expect(body).not.toContain(OTHER_TITLE)
+    })
+
+    RUN_DB_TEST('shows the create empty state for a valid lecturer and date', async function () {
+      const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: STUDENT_USERNAME })
+      const response = await fetch(
+        `${baseUrl}/join_consultation?lecturerId=${TEST_FILTER_LECTURER_ID}&date=${MONDAY_DATE}`,
+        { headers: { cookie: sessionCookie } }
+      )
+      const body = await response.text()
+
+      expect(response.status).toBe(200)
+      expect(body).toContain('No matching consultations')
+      expect(body).toContain('Create')
+    })
+
+    RUN_DB_TEST('shows the violation empty state when the time is outside the lecturer schedule', async function () {
+      const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: STUDENT_USERNAME })
+      const response = await fetch(
+        `${baseUrl}/join_consultation?lecturerId=${TEST_FILTER_LECTURER_ID}&date=${MONDAY_DATE}&time=13%3A00`,
+        { headers: { cookie: sessionCookie } }
+      )
+      const body = await response.text()
+
+      expect(response.status).toBe(200)
+      expect(body).toContain('Violates lecturer preferences')
+    })
   })
 
   RUN_DB_TEST('returns the mapped join error when a consultation is full', async function () {

--- a/tests/unit/models/consultation_db.test.js
+++ b/tests/unit/models/consultation_db.test.js
@@ -122,6 +122,44 @@ describe('consultation database operations', () => {
     })
   })
 
+  test('searchConsultationsForStudent queries all consultations when no filters are given', async () => {
+    const toArray = jest.fn().mockResolvedValue([])
+    mockConsultationCollection.find.mockReturnValue({ toArray })
+
+    await searchConsultationsForStudent({ username: 'student1' })
+
+    expect(mockConsultationCollection.find).toHaveBeenCalledWith({})
+  })
+
+  test('searchConsultationsForStudent filters by lecturerId when provided', async () => {
+    const toArray = jest.fn().mockResolvedValue([])
+    mockConsultationCollection.find.mockReturnValue({ toArray })
+
+    await searchConsultationsForStudent({ username: 'student1', lecturerId: 'lecturer1' })
+
+    expect(mockConsultationCollection.find).toHaveBeenCalledWith({ lecturerId: 'lecturer1' })
+  })
+
+  test('searchConsultationsForStudent filters by date range when only date is provided', async () => {
+    const toArray = jest.fn().mockResolvedValue([])
+    mockConsultationCollection.find.mockReturnValue({ toArray })
+
+    await searchConsultationsForStudent({ username: 'student1', date: '2026-05-04' })
+
+    expect(mockConsultationCollection.find).toHaveBeenCalledWith({
+      datetime: { $gte: '2026-05-04T00:00', $lt: '2026-05-04T23:59~' }
+    })
+  })
+
+  test('searchConsultationsForStudent filters by exact datetime when date and time are both provided', async () => {
+    const toArray = jest.fn().mockResolvedValue([])
+    mockConsultationCollection.find.mockReturnValue({ toArray })
+
+    await searchConsultationsForStudent({ username: 'student1', date: '2026-05-04', time: '09:00' })
+
+    expect(mockConsultationCollection.find).toHaveBeenCalledWith({ datetime: '2026-05-04T09:00' })
+  })
+
   test('searchConsultationsForStudent only returns consultations in the future', async () => {
     const now = new Date()
     const futureDate = new Date(now.getTime() + 24 * 60 * 60 * 1000).toISOString().slice(0, 16)

--- a/tests/unit/routes/join_consultation.test.js
+++ b/tests/unit/routes/join_consultation.test.js
@@ -1,0 +1,277 @@
+jest.mock('../../../src/models/consultation_db', () => ({
+  addStudentToConsultation: jest.fn(),
+  JOIN_RESULT_REASONS: {
+    ALREADY_JOINED: 'already-joined',
+    FULL: 'full',
+    NOT_FOUND: 'not-found'
+  },
+  searchConsultationsForStudent: jest.fn()
+}))
+
+jest.mock('../../../src/models/db', () => ({
+  connectToDatabase: jest.fn().mockResolvedValue(undefined)
+}))
+
+jest.mock('../../../src/models/user_db', () => ({
+  searchLecturers: jest.fn()
+}))
+
+jest.mock('../../../src/models/lecturer_availability_db', () => ({
+  getLecturerAvailability: jest.fn()
+}))
+
+const http = require('node:http')
+const path = require('node:path')
+const express = require('express')
+
+const { addStudentToConsultation, JOIN_RESULT_REASONS, searchConsultationsForStudent } = require('../../../src/models/consultation_db')
+const { connectToDatabase } = require('../../../src/models/db')
+const { getLecturerAvailability } = require('../../../src/models/lecturer_availability_db')
+const { searchLecturers } = require('../../../src/models/user_db')
+const joinConsultationRouter = require('../../../src/routes/join_consultation')
+
+const closeServer = async function (server) {
+  if (!server) {
+    return
+  }
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+
+    if (typeof server.closeIdleConnections === 'function') {
+      server.closeIdleConnections()
+    }
+
+    if (typeof server.closeAllConnections === 'function') {
+      server.closeAllConnections()
+    }
+  })
+}
+
+let currentSessionUser = {
+  facultyId: '',
+  role: 'student',
+  schoolId: '',
+  universityId: 'Wits',
+  username: 'morris'
+}
+
+const createServer = async function () {
+  const app = express()
+  const server = http.createServer(app)
+
+  app.set('view engine', 'ejs')
+  app.set('views', path.resolve(__dirname, '../../../src/views'))
+  app.use(express.urlencoded({ extended: true }))
+  app.use((req, res, next) => {
+    req.session = { user: currentSessionUser }
+    next()
+  })
+  app.use('/join_consultation', joinConsultationRouter)
+
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+
+  return server
+}
+
+describe('join consultation route', () => {
+  let baseUrl
+  let server
+
+  const MONDAY_AVAILABILITY = {
+    duration: 60,
+    exceptionDates: [],
+    weeklyAvailability: [{ day: 'monday', startTime: '08:00', endTime: '12:00' }]
+  }
+
+  beforeAll(async () => {
+    server = await createServer()
+    baseUrl = `http://127.0.0.1:${server.address().port}`
+  })
+
+  afterAll(async () => {
+    await closeServer(server)
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    currentSessionUser = {
+      facultyId: '',
+      role: 'student',
+      schoolId: '',
+      universityId: 'Wits',
+      username: 'morris'
+    }
+    connectToDatabase.mockResolvedValue(undefined)
+    searchConsultationsForStudent.mockResolvedValue([])
+    searchLecturers.mockResolvedValue([])
+    getLecturerAvailability.mockResolvedValue(MONDAY_AVAILABILITY)
+    addStudentToConsultation.mockResolvedValue({ success: true })
+  })
+
+  test('renders the join consultation page', async () => {
+    const response = await fetch(`${baseUrl}/join_consultation`)
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('<title>Join Consultation</title>')
+    expect(searchConsultationsForStudent).toHaveBeenCalledWith({
+      date: '',
+      lecturerId: '',
+      time: '',
+      username: 'morris'
+    })
+  })
+
+  test('passes the lecturerId filter to searchConsultationsForStudent', async () => {
+    const response = await fetch(`${baseUrl}/join_consultation?lecturerId=lecturer1`)
+
+    expect(response.status).toBe(200)
+    expect(searchConsultationsForStudent).toHaveBeenCalledWith({
+      date: '',
+      lecturerId: 'lecturer1',
+      time: '',
+      username: 'morris'
+    })
+  })
+
+  test('passes the date filter to searchConsultationsForStudent', async () => {
+    const response = await fetch(`${baseUrl}/join_consultation?date=2026-05-04`)
+
+    expect(response.status).toBe(200)
+    expect(searchConsultationsForStudent).toHaveBeenCalledWith({
+      date: '2026-05-04',
+      lecturerId: '',
+      time: '',
+      username: 'morris'
+    })
+  })
+
+  test('shows the create empty state when no consultations are found for a valid lecturer and date', async () => {
+    const response = await fetch(`${baseUrl}/join_consultation?lecturerId=lecturer1&date=2026-05-04`)
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(getLecturerAvailability).toHaveBeenCalledWith('lecturer1')
+    expect(body).toContain('No matching consultations')
+    expect(body).toContain('lecturerId=lecturer1')
+    expect(body).toContain('date=2026-05-04')
+  })
+
+  test('includes the time in the create link when a time filter is provided', async () => {
+    const response = await fetch(`${baseUrl}/join_consultation?lecturerId=lecturer1&date=2026-05-04&time=09%3A00`)
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('time=09%3A00')
+  })
+
+  test('shows the violation empty state when the time is outside the lecturer schedule', async () => {
+    const response = await fetch(`${baseUrl}/join_consultation?lecturerId=lecturer1&date=2026-05-04&time=13%3A00`)
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('Violates lecturer preferences')
+  })
+
+  test('does not check availability when lecturerId is not provided', async () => {
+    const response = await fetch(`${baseUrl}/join_consultation?date=2026-05-04`)
+
+    expect(response.status).toBe(200)
+    expect(getLecturerAvailability).not.toHaveBeenCalled()
+  })
+
+  test('returns a server error when loading the page fails', async () => {
+    connectToDatabase.mockRejectedValueOnce(new Error('database unavailable'))
+
+    const response = await fetch(`${baseUrl}/join_consultation`)
+    const body = await response.text()
+
+    expect(response.status).toBe(500)
+    expect(body).toContain('Unable to load join consultations right now.')
+  })
+
+  test('returns success JSON when joining a consultation succeeds', async () => {
+    const response = await fetch(`${baseUrl}/join_consultation/abc123/join`, {
+      headers: { accept: 'application/json' },
+      method: 'POST'
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ success: true })
+  })
+
+  test('returns error JSON when the consultation is full', async () => {
+    addStudentToConsultation.mockResolvedValueOnce({
+      reason: JOIN_RESULT_REASONS.FULL,
+      statusCode: 400,
+      success: false
+    })
+
+    const response = await fetch(`${baseUrl}/join_consultation/abc123/join`, {
+      headers: { accept: 'application/json' },
+      method: 'POST'
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data).toEqual({ error: 'This consultation is already full.', success: false })
+  })
+
+  test('returns error JSON when the student has already joined', async () => {
+    addStudentToConsultation.mockResolvedValueOnce({
+      reason: JOIN_RESULT_REASONS.ALREADY_JOINED,
+      statusCode: 400,
+      success: false
+    })
+
+    const response = await fetch(`${baseUrl}/join_consultation/abc123/join`, {
+      headers: { accept: 'application/json' },
+      method: 'POST'
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data).toEqual({ error: 'You have already joined this consultation.', success: false })
+  })
+
+  test('returns error JSON when the consultation is not found', async () => {
+    addStudentToConsultation.mockResolvedValueOnce({
+      reason: JOIN_RESULT_REASONS.NOT_FOUND,
+      statusCode: 404,
+      success: false
+    })
+
+    const response = await fetch(`${baseUrl}/join_consultation/abc123/join`, {
+      headers: { accept: 'application/json' },
+      method: 'POST'
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data).toEqual({ error: 'Consultation not found.', success: false })
+  })
+
+  test('returns a server error when joining fails', async () => {
+    addStudentToConsultation.mockRejectedValueOnce(new Error('database unavailable'))
+
+    const response = await fetch(`${baseUrl}/join_consultation/abc123/join`, {
+      headers: { accept: 'application/json' },
+      method: 'POST'
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Unable to join consultation right now.', success: false })
+  })
+})

--- a/tests/unit/services/consultation_availability_validation.test.js
+++ b/tests/unit/services/consultation_availability_validation.test.js
@@ -1,5 +1,7 @@
 const {
   addMinutesToTime,
+  getWeekdayFromIso,
+  isDateAvailableForLecturer,
   validateLecturerAvailability
 } = require('../../../src/services/consultation_availability_validation')
 
@@ -134,5 +136,72 @@ describe('consultation availability validation', () => {
     expect(findOverlappingConsultation({ scheduledConsultations: 'not-array', proposedStart: '10:00', duration: 60 })).toBeNull()
     expect(findOverlappingConsultation({ scheduledConsultations: [], proposedStart: '25:00', duration: 60 })).toBeNull()
     expect(findOverlappingConsultation({ scheduledConsultations: [], proposedStart: '10:00', duration: -5 })).toBeNull()
+  })
+
+  test('getWeekdayFromIso returns the weekday for a known Monday date', () => {
+    expect(getWeekdayFromIso('2026-05-04')).toBe('monday')
+  })
+
+  test('getWeekdayFromIso returns the weekday for a known Sunday date', () => {
+    expect(getWeekdayFromIso('2026-05-10')).toBe('sunday')
+  })
+
+  test('getWeekdayFromIso returns empty string for an invalid date', () => {
+    expect(getWeekdayFromIso('not-a-date')).toBe('')
+  })
+
+  describe('isDateAvailableForLecturer', () => {
+    const MONDAY_AVAILABILITY = {
+      duration: 60,
+      exceptionDates: [],
+      weeklyAvailability: [{ day: 'monday', startTime: '08:00', endTime: '12:00' }]
+    }
+    const MONDAY = '2026-05-04'
+    const TUESDAY = '2026-05-05'
+
+    test('returns false when availability is null', () => {
+      expect(isDateAvailableForLecturer(null, MONDAY, '')).toBe(false)
+    })
+
+    test('returns false when the date is an exception date', () => {
+      expect(isDateAvailableForLecturer(
+        { ...MONDAY_AVAILABILITY, exceptionDates: [MONDAY] },
+        MONDAY,
+        ''
+      )).toBe(false)
+    })
+
+    test('returns false when the weekday is not in the weekly availability', () => {
+      expect(isDateAvailableForLecturer(MONDAY_AVAILABILITY, TUESDAY, '')).toBe(false)
+    })
+
+    test('returns true when the date is available and no time is provided', () => {
+      expect(isDateAvailableForLecturer(MONDAY_AVAILABILITY, MONDAY, '')).toBe(true)
+    })
+
+    test('returns true when the proposed time fits within the slot', () => {
+      expect(isDateAvailableForLecturer(MONDAY_AVAILABILITY, MONDAY, '09:00')).toBe(true)
+    })
+
+    test('returns false when the proposed time is before the slot start', () => {
+      expect(isDateAvailableForLecturer(MONDAY_AVAILABILITY, MONDAY, '07:00')).toBe(false)
+    })
+
+    test('returns false when the consultation would end after the slot end', () => {
+      expect(isDateAvailableForLecturer(MONDAY_AVAILABILITY, MONDAY, '11:30')).toBe(false)
+    })
+
+    test('returns true when the consultation ends exactly at the slot end', () => {
+      expect(isDateAvailableForLecturer(MONDAY_AVAILABILITY, MONDAY, '11:00')).toBe(true)
+    })
+
+    test('returns true when the time format is invalid, falling back to date-only check', () => {
+      expect(isDateAvailableForLecturer(MONDAY_AVAILABILITY, MONDAY, 'badtime')).toBe(true)
+    })
+
+    test('defaults duration to 60 when not specified in availability', () => {
+      const noDuration = { exceptionDates: [], weeklyAvailability: MONDAY_AVAILABILITY.weeklyAvailability }
+      expect(isDateAvailableForLecturer(noDuration, MONDAY, '11:00')).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
Closes #31

Summary: Add lecturer, date, and time search filters to the join consultation page with availability-aware empty states. When a filtered search returns no results, the page either prompts students to create a new consultation (when the date and time fall within the lecturer's availability) or informs them that the selection violates the lecturer's preferences. A compact inline Create button pre-fills the create consultation form with the selected lecturer and datetime.

## Key Changes

- **Search filters:** Added lecturer dropdown, date picker, and 15-minute-increment time picker to the join consultation page. Filters are applied server-side through `searchConsultationsForStudent`, which was extended with optional `lecturerId`, `date`, and `time` params while remaining backward-compatible with existing callers.
- **Empty states:** When filters return no results for a specific lecturer and date, the route calls `getLecturerAvailability` and `isDateAvailableForLecturer` to decide between two states: `'create'` (date and time are within the lecturer's availability window) or `'violation'` (outside the window).
- **New service function:** `isDateAvailableForLecturer` added to `consultation_availability_validation.js` — checks a date and optional start time against the lecturer's weekly slots, exception dates, and configured duration.
- **Pre-fill redirect:** The Create link passes `lecturerId`, `date`, and `time` as query params; `GET /consultations/new` already reads these to pre-fill the form's lecturer select and datetime-local input.
- **UI:** Empty-state Create button is styled as a compact inline element (`.button_compact`) rather than a full-width success button.
- **Time input constraint:** Client-side `updateTimeMin` prevents selecting a past time when today's date is chosen, and clears any previously entered time that would have become invalid.
- **Tests:** Unit tests for `getWeekdayFromIso` and `isDateAvailableForLecturer`; unit tests for `searchConsultationsForStudent` query construction; new `join_consultation` route unit test suite covering all GET filter paths and all POST join outcomes; integration tests for lecturer filter and both empty states; E2E test for the search → empty state → Create → pre-filled form flow.
- **Docs:** JSDoc added to all new and updated functions across `consultation_availability_validation.js`, `consultation_db.js`, `join_consultation.js`, and `join_consultation_search.js`.

## Acceptance

- Students searching by lecturer, date, or time see only matching future consultations.
- When no consultations match a specific lecturer and date that falls within the lecturer's availability, the page shows "No matching consultations. Create new consultation?" with a compact Create button inline.
- Clicking Create navigates to the create form with the lecturer and datetime pre-filled from the search.
- When the selected time falls outside the lecturer's availability window, the page shows "No matching consultation - Violates lecturer preferences."
- Selecting today's date prevents choosing a past time; any stale time value is automatically cleared.

## How to test locally

- Run full test suite: `npm test`
- Run only unit tests: `npm run test:unit`
- Run E2E (requires writable test MongoDB): `npm run test:e2e`

## Notes

- `buildLecturerOptions` is intentionally duplicated in `join_consultation.js` rather than extracted to a shared utility, to keep the route modules independently maintainable.
- `isDateAvailableForLecturer` is intentionally lighter than `validateLecturerAvailability` — it omits daily cap and overlap checks, which only apply at creation time.
- Integration and E2E tests for the empty states use a process-unique test lecturer ID to avoid interfering with seeded test data.
