### PR TITLE
Student calendar

### DIFF
--- a/src/models/consultation_db.js
+++ b/src/models/consultation_db.js
@@ -132,10 +132,12 @@ const searchConsultationsForStudent = async function ({
 }
 
 /**
- * Adds a student attendee to an existing consultation when space remains.
- * @param {string} consultationId - Consultation id string.
- * @param {string} username - Student username.
- * @returns {Promise<{success: boolean, reason?: string, statusCode?: number}>} Join result.
+ * Returns upcoming consultations within a month range for display on the student calendar.
+ * Excludes past consultations. Each entry includes the student's join status and whether the consultation is full.
+ * @param {string} username - The student's username.
+ * @param {string} monthStart - Start of the month range in 'YYYY-MM-DDTHH:MM' format.
+ * @param {string} monthEnd - End of the month range in 'YYYY-MM-DDTHH:MM~' format.
+ * @returns {Promise<Array<object>>} Enriched consultation objects for calendar display.
  */
 const getConsultationsForCalendar = async function (username, monthStart, monthEnd) {
   const consultations = await consultationsCollection().find({
@@ -184,6 +186,12 @@ const getConsultationsForCalendar = async function (username, monthStart, monthE
   }).filter(Boolean)
 }
 
+/**
+ * Adds a student attendee to an existing consultation when space remains.
+ * @param {string} consultationId - Consultation id string.
+ * @param {string} username - Student username.
+ * @returns {Promise<{success: boolean, reason?: string, statusCode?: number}>} Join result.
+ */
 const addStudentToConsultation = async function (consultationId, username) {
   if (!ObjectId.isValid(consultationId)) {
     return { success: false, reason: JOIN_RESULT_REASONS.NOT_FOUND, statusCode: 404 }

--- a/src/models/consultation_db.js
+++ b/src/models/consultation_db.js
@@ -137,6 +137,53 @@ const searchConsultationsForStudent = async function ({
  * @param {string} username - Student username.
  * @returns {Promise<{success: boolean, reason?: string, statusCode?: number}>} Join result.
  */
+const getConsultationsForCalendar = async function (username, monthStart, monthEnd) {
+  const consultations = await consultationsCollection().find({
+    datetime: { $gte: monthStart, $lt: monthEnd }
+  }).toArray()
+
+  if (consultations.length === 0) return []
+
+  const lecturerIds = [...new Set(consultations.map(function (c) {
+    return c.lecturerId
+  }).filter(Boolean))]
+
+  const [users, availabilities] = await Promise.all([
+    usersCollection().find({ username: { $in: lecturerIds } }).toArray(),
+    getCollection(AVAILABILITY_COLLECTION_NAME).find({ username: { $in: lecturerIds } }).toArray()
+  ])
+
+  const usersByUsername = new Map(users.map(function (u) {
+    return [u.username, u]
+  }))
+  const availabilitiesByUsername = new Map(availabilities.map(function (a) {
+    return [a.username, a]
+  }))
+
+  const now = new Date()
+
+  return consultations.map(function (consultation) {
+    if (!consultation._id) return null
+    if (new Date(consultation.datetime) <= now) return null
+
+    const startTime = consultation.datetime?.slice(11, 16) || ''
+    const endTime = addMinutesToTime(startTime, availabilitiesByUsername.get(consultation.lecturerId)?.duration) || startTime
+    const time = startTime ? `${startTime} to ${endTime}` : ''
+    const attendees = Array.isArray(consultation.attendees) ? consultation.attendees : []
+    const hasCapacity = Number.isInteger(consultation.capacity)
+
+    return {
+      date: consultation.datetime?.slice(0, 10) || '',
+      hasJoined: attendees.includes(username),
+      id: consultation._id.toString(),
+      isFull: hasCapacity && attendees.length >= consultation.capacity,
+      lecturer: buildDisplayName(usersByUsername.get(consultation.lecturerId), consultation.lecturerId),
+      name: consultation.title || 'Untitled consultation',
+      time
+    }
+  }).filter(Boolean)
+}
+
 const addStudentToConsultation = async function (consultationId, username) {
   if (!ObjectId.isValid(consultationId)) {
     return { success: false, reason: JOIN_RESULT_REASONS.NOT_FOUND, statusCode: 404 }
@@ -169,6 +216,7 @@ const addStudentToConsultation = async function (consultationId, username) {
 module.exports = {
   addConsultation,
   addStudentToConsultation,
+  getConsultationsForCalendar,
   JOIN_RESULT_REASONS,
   listConsultationsForLecturerOnDate,
   searchConsultationsForStudent

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -281,6 +281,20 @@ a {
   text-align: right;
 }
 
+
+.calendar_day_note_joined {
+  color: #166534;
+  font-weight: 600;
+}
+
+.calendar_day_note_unjoined {
+  color: #9ca3af;
+}
+
+.calendar_day_note_full {
+  color: #c2410c;
+}
+
 .calendar_day_available {
   background: #dcfce7;
 }

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -2,6 +2,7 @@
 
 const express = require('express')
 const { connectToDatabase } = require('../models/db')
+const { getConsultationsForCalendar } = require('../models/consultation_db')
 const { getLecturerAvailability } = require('../models/lecturer_availability_db')
 const { searchLecturers } = require('../models/user_db')
 const { buildCurrentMonthCalendar } = require('../utils/calendar')
@@ -34,7 +35,7 @@ router.get('/', async (req, res) => {
   }
 
   if (role !== 'student') {
-    return res.render('home', { title, homeTitle, role, username, calendar, lecturers: [], faculties: [], schools: [], query: '', facultyId: '', schoolId: '', page: 1, totalPages: 0 })
+    return res.render('home', { title, homeTitle, role, username, calendar, consultationsByDate: {}, lecturers: [], faculties: [], schools: [], query: '', facultyId: '', schoolId: '', page: 1, totalPages: 0 })
   }
 
   const query = req.query.q?.trim() || ''
@@ -42,9 +43,28 @@ router.get('/', async (req, res) => {
   const schoolId = req.query.schoolId?.trim() || ''
   const page = Math.max(1, parseInt(req.query.page) || 1)
 
+  const calendarNow = new Date()
+  const calendarYear = calendarNow.getFullYear()
+  const calendarMonth = calendarNow.getMonth()
+  const paddedMonth = String(calendarMonth + 1).padStart(2, '0')
+  const daysInCalendarMonth = new Date(calendarYear, calendarMonth + 1, 0).getDate()
+  const monthStart = `${calendarYear}-${paddedMonth}-01T00:00`
+  const monthEnd = `${calendarYear}-${paddedMonth}-${String(daysInCalendarMonth).padStart(2, '0')}T23:59~`
+
   try {
     await connectToDatabase()
-    const allLecturers = await searchLecturers({ universityId, query })
+    const [allLecturers, calendarConsultations] = await Promise.all([
+      searchLecturers({ universityId, query }),
+      getConsultationsForCalendar(username, monthStart, monthEnd)
+    ])
+
+    const consultationsByDate = {}
+    calendarConsultations.forEach(function (consultation) {
+      if (!consultationsByDate[consultation.date]) {
+        consultationsByDate[consultation.date] = []
+      }
+      consultationsByDate[consultation.date].push(consultation)
+    })
 
     const faculties = [...new Set(allLecturers.map(l => l.facultyId).filter(Boolean))]
     const filteredLecturers = allLecturers.filter(l =>
@@ -65,12 +85,12 @@ router.get('/', async (req, res) => {
     if (req.headers.accept?.includes('application/json')) {
       return res.json({ lecturers, page: currentPage, totalPages })
     }
-    return res.render('home', { title, homeTitle, role, username, calendar, lecturers, faculties, schools, query, facultyId, schoolId, page: currentPage, totalPages })
+    return res.render('home', { title, homeTitle, role, username, calendar, consultationsByDate, lecturers, faculties, schools, query, facultyId, schoolId, page: currentPage, totalPages })
   } catch {
     if (req.headers.accept?.includes('application/json')) {
       return res.json({ lecturers: [], page: 1, totalPages: 0 })
     }
-    return res.render('home', { title, homeTitle, role, username, calendar, lecturers: [], faculties: [], schools: [], query, facultyId, schoolId, page: 1, totalPages: 0 })
+    return res.render('home', { title, homeTitle, role, username, calendar, consultationsByDate: {}, lecturers: [], faculties: [], schools: [], query, facultyId, schoolId, page: 1, totalPages: 0 })
   }
 })
 

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -54,7 +54,20 @@
           <% calendar.weeks.forEach(function (week) { %>
             <tr>
               <% week.forEach(function (day) { %>
-                <% if (!day.isEmpty) { %>
+                <% if (day.isEmpty) { %>
+                  <td class="calendar_day calendar_day_empty"></td>
+                <% } else if (role === 'student') { %>
+                  <% const dayCons = consultationsByDate[day.isoDate] || [] %>
+                  <td class="calendar_day">
+                    <div class="calendar_day_content">
+                      <span class="calendar_day_number"><%= day.dayNumber %></span>
+                      <% dayCons.forEach(function (con) { %>
+                        <% const statusLabel = con.hasJoined ? 'Joined' : con.isFull ? 'Fully Booked' : 'Unjoined' %>
+                        <span class="calendar_day_note <%= con.hasJoined ? 'calendar_day_note_joined' : con.isFull ? 'calendar_day_note_full' : 'calendar_day_note_unjoined' %>"><%= con.name %> &middot; <%= con.lecturer %> &middot; <%= con.time %> &middot; <%= statusLabel %></span>
+                      <% }) %>
+                    </div>
+                  </td>
+                <% } else { %>
                   <td class="calendar_day<%= day.availabilityState === 'available' ? ' calendar_day_available' : '' %><%= day.availabilityState === 'unavailable' ? ' calendar_day_unavailable' : '' %>">
                     <div class="calendar_day_content">
                       <span class="calendar_day_number"><%= day.dayNumber %></span>
@@ -63,8 +76,6 @@
                       <% } %>
                     </div>
                   </td>
-                <% } else { %>
-                  <td class="calendar_day calendar_day_empty"></td>
                 <% } %>
               <% }) %>
             </tr>

--- a/tests/E2E/home.js
+++ b/tests/E2E/home.js
@@ -1,0 +1,96 @@
+const path = require('node:path')
+const { test, expect } = require('@playwright/test')
+const { connectToDatabase, closeDatabaseConnection, getCollection } = require('../../src/models/db')
+require('dotenv').config({ path: path.resolve(__dirname, '../../.env'), quiet: true })
+
+const PASSWORD = 'password'
+const STUDENT_USERNAME = 'user'
+const LECTURER_USERNAME = 'user1'
+const TEST_ID = `${process.pid}${Date.now()}`
+const TEST_TITLE_PREFIX = 'home-calendar-e2e-'
+
+const deleteTestConsultations = async function () {
+  await connectToDatabase()
+  await getCollection('Consultation').deleteMany({ title: { $regex: `^${TEST_TITLE_PREFIX}` } })
+}
+
+const getFutureCurrentMonthDatetime = function () {
+  const future = new Date(Date.now() + 2 * 60 * 60 * 1000)
+  const year = future.getFullYear()
+  const month = String(future.getMonth() + 1).padStart(2, '0')
+  const day = String(future.getDate()).padStart(2, '0')
+  const hours = String(future.getHours()).padStart(2, '0')
+  const minutes = String(future.getMinutes()).padStart(2, '0')
+  return `${year}-${month}-${day}T${hours}:${minutes}`
+}
+
+test.describe('home calendar E2E', () => {
+  test.skip(!process.env.MONGODB_URI, 'Requires a writable MongoDB test database.')
+
+  test.beforeEach(async function () {
+    await deleteTestConsultations()
+  })
+
+  test.afterEach(async function () {
+    await deleteTestConsultations()
+  })
+
+  test.afterAll(async function () {
+    await deleteTestConsultations()
+    await closeDatabaseConnection()
+  })
+
+  test('student home calendar shows joined, unjoined, and fully booked consultations', async ({ page }) => {
+    const datetime = getFutureCurrentMonthDatetime()
+    const joinedTitle = `${TEST_TITLE_PREFIX}joined-${TEST_ID}`
+    const unjoinedTitle = `${TEST_TITLE_PREFIX}unjoined-${TEST_ID}`
+    const fullTitle = `${TEST_TITLE_PREFIX}full-${TEST_ID}`
+
+    await connectToDatabase()
+    await getCollection('Consultation').insertMany([
+      {
+        attendees: [STUDENT_USERNAME],
+        capacity: 5,
+        datetime,
+        lecturerId: LECTURER_USERNAME,
+        organiserId: STUDENT_USERNAME,
+        title: joinedTitle
+      },
+      {
+        attendees: [],
+        capacity: 5,
+        datetime,
+        lecturerId: LECTURER_USERNAME,
+        organiserId: 'organiser1',
+        title: unjoinedTitle
+      },
+      {
+        attendees: ['student2'],
+        capacity: 1,
+        datetime,
+        lecturerId: LECTURER_USERNAME,
+        organiserId: 'student2',
+        title: fullTitle
+      }
+    ])
+
+    await page.goto('/login')
+    await page.getByRole('textbox', { name: 'Username' }).fill(STUDENT_USERNAME)
+    await page.getByLabel('Password').fill(PASSWORD)
+    await page.getByRole('button', { name: 'Log In' }).click()
+
+    await expect(page).toHaveURL(/\/home$/)
+
+    const joinedNote = page.locator('.calendar_day_note_joined').filter({ hasText: joinedTitle })
+    const unjoinedNote = page.locator('.calendar_day_note_unjoined').filter({ hasText: unjoinedTitle })
+    const fullNote = page.locator('.calendar_day_note_full').filter({ hasText: fullTitle })
+
+    await expect(joinedNote).toBeVisible()
+    await expect(unjoinedNote).toBeVisible()
+    await expect(fullNote).toBeVisible()
+
+    await expect(joinedNote).toContainText('Joined')
+    await expect(unjoinedNote).toContainText('Unjoined')
+    await expect(fullNote).toContainText('Fully Booked')
+  })
+})

--- a/tests/integration/home.test.js
+++ b/tests/integration/home.test.js
@@ -1,0 +1,187 @@
+const http = require('node:http')
+const { closeDatabaseConnection, connectToDatabase, getCollection } = require('../../src/models/db')
+const app = require('../../src/app')
+
+const LECTURER_USERNAME = 'user1'
+const PASSWORD = 'password'
+const RUN_DB_TEST = process.env.MONGODB_URI ? test : test.skip
+const STUDENT_USERNAME = 'user'
+const TEST_ID = `${process.pid}${Date.now()}`
+const TEST_TITLE_PREFIX = 'home-calendar-integration-'
+
+let baseUrl
+let server
+
+const closeServer = async function (server) {
+  if (!server) return
+
+  await new Promise(function (resolve, reject) {
+    server.close(function (error) {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+
+    if (typeof server.closeIdleConnections === 'function') server.closeIdleConnections()
+    if (typeof server.closeAllConnections === 'function') server.closeAllConnections()
+  })
+}
+
+const encodeForm = function (fields) {
+  return new URLSearchParams(fields).toString()
+}
+
+const loginAs = async function (baseUrl, { password, username }) {
+  const response = await fetch(`${baseUrl}/login`, {
+    body: encodeForm({ password, username }),
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    method: 'POST',
+    redirect: 'manual'
+  })
+
+  return response.headers.get('set-cookie')?.split(';')[0] || ''
+}
+
+const deleteTestConsultations = async function () {
+  await connectToDatabase()
+  await getCollection('Consultation').deleteMany({ title: { $regex: `^${TEST_TITLE_PREFIX}` } })
+}
+
+const getFutureCurrentMonthDatetime = function () {
+  const future = new Date(Date.now() + 2 * 60 * 60 * 1000)
+  const year = future.getFullYear()
+  const month = String(future.getMonth() + 1).padStart(2, '0')
+  const day = String(future.getDate()).padStart(2, '0')
+  const hours = String(future.getHours()).padStart(2, '0')
+  const minutes = String(future.getMinutes()).padStart(2, '0')
+  return `${year}-${month}-${day}T${hours}:${minutes}`
+}
+
+describe('home calendar integration', () => {
+  beforeAll(async function () {
+    if (!process.env.MONGODB_URI) return
+
+    server = http.createServer(app)
+
+    await new Promise(function (resolve) {
+      server.listen(0, '127.0.0.1', function () {
+        baseUrl = `http://127.0.0.1:${server.address().port}`
+        resolve()
+      })
+    })
+  })
+
+  beforeEach(async function () {
+    if (!process.env.MONGODB_URI) return
+    await deleteTestConsultations()
+  })
+
+  afterEach(async function () {
+    if (!process.env.MONGODB_URI) return
+    await deleteTestConsultations()
+  })
+
+  afterAll(async function () {
+    if (!process.env.MONGODB_URI) return
+    await deleteTestConsultations()
+    await closeServer(server)
+    await closeDatabaseConnection()
+  })
+
+  RUN_DB_TEST('shows a joined consultation on the student home calendar', async function () {
+    const datetime = getFutureCurrentMonthDatetime()
+    const title = `${TEST_TITLE_PREFIX}joined-${TEST_ID}`
+
+    await connectToDatabase()
+    await getCollection('Consultation').insertOne({
+      attendees: [STUDENT_USERNAME],
+      capacity: 5,
+      datetime,
+      lecturerId: LECTURER_USERNAME,
+      organiserId: STUDENT_USERNAME,
+      title
+    })
+
+    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: STUDENT_USERNAME })
+    const response = await fetch(`${baseUrl}/home`, { headers: { cookie: sessionCookie } })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain(title)
+    expect(body).toContain('Joined')
+    expect(body).toContain('calendar_day_note_joined')
+  })
+
+  RUN_DB_TEST('shows an unjoined consultation on the student home calendar', async function () {
+    const datetime = getFutureCurrentMonthDatetime()
+    const title = `${TEST_TITLE_PREFIX}unjoined-${TEST_ID}`
+
+    await connectToDatabase()
+    await getCollection('Consultation').insertOne({
+      attendees: [],
+      capacity: 5,
+      datetime,
+      lecturerId: LECTURER_USERNAME,
+      organiserId: 'organiser1',
+      title
+    })
+
+    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: STUDENT_USERNAME })
+    const response = await fetch(`${baseUrl}/home`, { headers: { cookie: sessionCookie } })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain(title)
+    expect(body).toContain('Unjoined')
+    expect(body).toContain('calendar_day_note_unjoined')
+  })
+
+  RUN_DB_TEST('shows a fully booked consultation on the student home calendar', async function () {
+    const datetime = getFutureCurrentMonthDatetime()
+    const title = `${TEST_TITLE_PREFIX}full-${TEST_ID}`
+
+    await connectToDatabase()
+    await getCollection('Consultation').insertOne({
+      attendees: ['student2'],
+      capacity: 1,
+      datetime,
+      lecturerId: LECTURER_USERNAME,
+      organiserId: 'student2',
+      title
+    })
+
+    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: STUDENT_USERNAME })
+    const response = await fetch(`${baseUrl}/home`, { headers: { cookie: sessionCookie } })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain(title)
+    expect(body).toContain('Fully Booked')
+    expect(body).toContain('calendar_day_note_full')
+  })
+
+  RUN_DB_TEST('does not show past consultations on the student home calendar', async function () {
+    const pastDatetime = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString().slice(0, 16)
+    const title = `${TEST_TITLE_PREFIX}past-${TEST_ID}`
+
+    await connectToDatabase()
+    await getCollection('Consultation').insertOne({
+      attendees: [],
+      capacity: 5,
+      datetime: pastDatetime,
+      lecturerId: LECTURER_USERNAME,
+      organiserId: 'organiser1',
+      title
+    })
+
+    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: STUDENT_USERNAME })
+    const response = await fetch(`${baseUrl}/home`, { headers: { cookie: sessionCookie } })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).not.toContain(title)
+  })
+})

--- a/tests/unit/models/consultation_db.test.js
+++ b/tests/unit/models/consultation_db.test.js
@@ -7,6 +7,7 @@ const { getCollection } = require('../../../src/models/db')
 const {
   addConsultation,
   addStudentToConsultation,
+  getConsultationsForCalendar,
   JOIN_RESULT_REASONS,
   listConsultationsForLecturerOnDate,
   searchConsultationsForStudent
@@ -158,6 +159,121 @@ describe('consultation database operations', () => {
     await searchConsultationsForStudent({ username: 'student1', date: '2026-05-04', time: '09:00' })
 
     expect(mockConsultationCollection.find).toHaveBeenCalledWith({ datetime: '2026-05-04T09:00' })
+  })
+
+  describe('getConsultationsForCalendar', () => {
+    const MONTH_START = '2030-06-01T00:00'
+    const MONTH_END = '2030-06-30T23:59~'
+    const FUTURE_DATE = '2030-06-15T10:00'
+
+    const setupMocks = function ({ consultations, users = [], availabilities = [] }) {
+      mockConsultationCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue(consultations) })
+      mockUserCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue(users) })
+      mockLecturerAvailabilityCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue(availabilities) })
+    }
+
+    test('queries the Consultation collection by month range', async () => {
+      setupMocks({ consultations: [] })
+
+      await getConsultationsForCalendar('student1', MONTH_START, MONTH_END)
+
+      expect(mockConsultationCollection.find).toHaveBeenCalledWith({
+        datetime: { $gte: MONTH_START, $lt: MONTH_END }
+      })
+    })
+
+    test('returns an empty array when no consultations exist in the month', async () => {
+      setupMocks({ consultations: [] })
+
+      const result = await getConsultationsForCalendar('student1', MONTH_START, MONTH_END)
+
+      expect(result).toEqual([])
+    })
+
+    test('excludes past consultations', async () => {
+      const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+      setupMocks({
+        consultations: [{ _id: new ObjectId(), attendees: [], capacity: 1, datetime: pastDate, lecturerId: 'lecturer1', title: 'Past' }],
+        users: [],
+        availabilities: []
+      })
+
+      const result = await getConsultationsForCalendar('student1', MONTH_START, MONTH_END)
+
+      expect(result).toHaveLength(0)
+    })
+
+    test('sets hasJoined to true when the student is an attendee', async () => {
+      setupMocks({
+        consultations: [{ _id: new ObjectId(), attendees: ['student1'], capacity: 2, datetime: FUTURE_DATE, lecturerId: 'lecturer1', title: 'DS Review' }],
+        users: [{ username: 'lecturer1', firstName: 'Jane', lastName: 'Doe' }],
+        availabilities: [{ username: 'lecturer1', duration: 60 }]
+      })
+
+      const result = await getConsultationsForCalendar('student1', MONTH_START, MONTH_END)
+
+      expect(result[0].hasJoined).toBe(true)
+    })
+
+    test('sets hasJoined to false when the student is not an attendee', async () => {
+      setupMocks({
+        consultations: [{ _id: new ObjectId(), attendees: ['otherStudent'], capacity: 2, datetime: FUTURE_DATE, lecturerId: 'lecturer1', title: 'DS Review' }],
+        users: [],
+        availabilities: []
+      })
+
+      const result = await getConsultationsForCalendar('student1', MONTH_START, MONTH_END)
+
+      expect(result[0].hasJoined).toBe(false)
+    })
+
+    test('sets isFull to true when attendees equals capacity', async () => {
+      setupMocks({
+        consultations: [{ _id: new ObjectId(), attendees: ['otherStudent'], capacity: 1, datetime: FUTURE_DATE, lecturerId: 'lecturer1', title: 'Full' }],
+        users: [],
+        availabilities: []
+      })
+
+      const result = await getConsultationsForCalendar('student1', MONTH_START, MONTH_END)
+
+      expect(result[0].isFull).toBe(true)
+    })
+
+    test('sets isFull to false when there is remaining capacity', async () => {
+      setupMocks({
+        consultations: [{ _id: new ObjectId(), attendees: [], capacity: 2, datetime: FUTURE_DATE, lecturerId: 'lecturer1', title: 'Available' }],
+        users: [],
+        availabilities: []
+      })
+
+      const result = await getConsultationsForCalendar('student1', MONTH_START, MONTH_END)
+
+      expect(result[0].isFull).toBe(false)
+    })
+
+    test('builds the lecturer display name from the user document', async () => {
+      setupMocks({
+        consultations: [{ _id: new ObjectId(), attendees: [], capacity: 1, datetime: FUTURE_DATE, lecturerId: 'lecturer1', title: 'DS Review' }],
+        users: [{ username: 'lecturer1', firstName: 'Jane', lastName: 'Doe' }],
+        availabilities: []
+      })
+
+      const result = await getConsultationsForCalendar('student1', MONTH_START, MONTH_END)
+
+      expect(result[0].lecturer).toBe('Jane Doe')
+    })
+
+    test('computes the end time from the start time and lecturer duration', async () => {
+      setupMocks({
+        consultations: [{ _id: new ObjectId(), attendees: [], capacity: 1, datetime: FUTURE_DATE, lecturerId: 'lecturer1', title: 'DS Review' }],
+        users: [],
+        availabilities: [{ username: 'lecturer1', duration: 60 }]
+      })
+
+      const result = await getConsultationsForCalendar('student1', MONTH_START, MONTH_END)
+
+      expect(result[0].time).toBe('10:00 to 11:00')
+    })
   })
 
   test('searchConsultationsForStudent only returns consultations in the future', async () => {

--- a/tests/unit/routes/home.test.js
+++ b/tests/unit/routes/home.test.js
@@ -489,6 +489,80 @@ describe('home route', () => {
     expect(data.totalPages).toBe(2)
   })
 
+  test('Shows consultation notes on the student calendar for the current month', async () => {
+    getConsultationsForCalendar.mockResolvedValue([{
+      date: getCurrentMonthDate(15),
+      hasJoined: false,
+      id: 'cons-1',
+      isFull: false,
+      lecturer: 'Jane Doe',
+      name: 'Project Review',
+      time: '09:00 to 10:00'
+    }])
+    const { sessionCookie } = await loginAs({ role: 'student', username: 'morris' })
+    const response = await fetch(`${baseUrl}/home`, { headers: { cookie: sessionCookie } })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('Project Review')
+    expect(body).toContain('Jane Doe')
+    expect(body).toContain('09:00 to 10:00')
+  })
+
+  test('Shows the Joined label for a consultation the student has joined', async () => {
+    getConsultationsForCalendar.mockResolvedValue([{
+      date: getCurrentMonthDate(15),
+      hasJoined: true,
+      id: 'cons-1',
+      isFull: false,
+      lecturer: 'Jane Doe',
+      name: 'Project Review',
+      time: '09:00 to 10:00'
+    }])
+    const { sessionCookie } = await loginAs({ role: 'student', username: 'morris' })
+    const response = await fetch(`${baseUrl}/home`, { headers: { cookie: sessionCookie } })
+    const body = await response.text()
+
+    expect(body).toContain('Joined')
+    expect(body).toContain('calendar_day_note_joined')
+  })
+
+  test('Shows the Unjoined label for a consultation the student has not joined', async () => {
+    getConsultationsForCalendar.mockResolvedValue([{
+      date: getCurrentMonthDate(15),
+      hasJoined: false,
+      id: 'cons-1',
+      isFull: false,
+      lecturer: 'Jane Doe',
+      name: 'Project Review',
+      time: '09:00 to 10:00'
+    }])
+    const { sessionCookie } = await loginAs({ role: 'student', username: 'morris' })
+    const response = await fetch(`${baseUrl}/home`, { headers: { cookie: sessionCookie } })
+    const body = await response.text()
+
+    expect(body).toContain('Unjoined')
+    expect(body).toContain('calendar_day_note_unjoined')
+  })
+
+  test('Shows the Fully Booked label for a full unjoined consultation', async () => {
+    getConsultationsForCalendar.mockResolvedValue([{
+      date: getCurrentMonthDate(15),
+      hasJoined: false,
+      id: 'cons-1',
+      isFull: true,
+      lecturer: 'Jane Doe',
+      name: 'Project Review',
+      time: '09:00 to 10:00'
+    }])
+    const { sessionCookie } = await loginAs({ role: 'student', username: 'morris' })
+    const response = await fetch(`${baseUrl}/home`, { headers: { cookie: sessionCookie } })
+    const body = await response.text()
+
+    expect(body).toContain('Fully Booked')
+    expect(body).toContain('calendar_day_note_full')
+  })
+
   test('Renders pagination links when there are more than 20 results', async () => {
     searchLecturers.mockResolvedValue(MOCK_LECTURERS_21)
     const { sessionCookie } = await loginAs({ role: 'student', username: 'testuser' })

--- a/tests/unit/routes/home.test.js
+++ b/tests/unit/routes/home.test.js
@@ -19,6 +19,7 @@ jest.mock('../../../src/models/user_db', () => ({
 }))
 
 jest.mock('../../../src/models/consultation_db', () => ({
+  getConsultationsForCalendar: jest.fn(),
   JOIN_RESULT_REASONS: {
     ALREADY_JOINED: 'already_joined',
     FULL: 'full',
@@ -57,7 +58,7 @@ const closeServer = async function (server) {
 const { connectToDatabase } = require('../../../src/models/db')
 const { getLecturerAvailability } = require('../../../src/models/lecturer_availability_db')
 const { getUser, searchLecturers } = require('../../../src/models/user_db')
-const { addConsultation } = require('../../../src/models/consultation_db')
+const { addConsultation, getConsultationsForCalendar } = require('../../../src/models/consultation_db')
 const { hashPassword } = require('../../../src/utils/password')
 const app = require('../../../src/app')
 
@@ -169,6 +170,7 @@ describe('home route', () => {
     jest.clearAllMocks()
     addConsultation.mockResolvedValue({ acknowledged: true, insertedId: 'consultation-id' })
     connectToDatabase.mockResolvedValue(undefined)
+    getConsultationsForCalendar.mockResolvedValue([])
     getLecturerAvailability.mockResolvedValue(null)
     searchLecturers.mockResolvedValue([])
   })


### PR DESCRIPTION
Closes #39

## Summary

- Adds a student-facing calendar on the home page that shows all upcoming consultations for the current month
- Each consultation note displays the topic, lecturer name, and time range, with an explicit status label: **Joined**, **Unjoined**, or **Fully Booked**
- Note text is colour-coded (green / grey / orange) to reinforce status at a glance
- Consultation data is fetched via a new `getConsultationsForCalendar` model function that excludes past consultations and enriches each record with `hasJoined` and `isFull` flags

## Test plan

- [ ] Unit tests added for `getConsultationsForCalendar` (query range, past exclusion, `hasJoined`, `isFull`, lecturer name, time range)
- [ ] Unit tests added for home route calendar rendering (notes displayed, all three status labels and CSS classes rendered correctly)
- [ ] Integration tests added (`tests/integration/home.test.js`) — joined, unjoined, and fully booked consultations each appear with the correct label against a real MongoDB instance; past consultations are excluded
- [ ] E2E tests added (`tests/E2E/home.js`) — Playwright verifies all three note CSS classes and status labels are visible in the browser after login
- [ ] `npm run test:unit` passes (163 tests)
- [ ] StandardJS lint passes on all changed files