### PR TITLE
fix(tests): Fix past dates test failing

### DIFF
--- a/tests/E2E/create_consultation.js
+++ b/tests/E2E/create_consultation.js
@@ -19,7 +19,7 @@ test.describe('create consultation E2E', () => {
     await setLecturerAvailability(TEST_LECTURER_USERNAME, {
       dailyMax: 2,
       duration: 60,
-      exceptionDates: ['2026-04-01'],
+      exceptionDates: ['2030-04-01'],
       maxStudents: 5,
       minStudents: 1,
       weeklyAvailability: [

--- a/tests/E2E/user_profile_page.js
+++ b/tests/E2E/user_profile_page.js
@@ -192,7 +192,7 @@ test.describe('user profile page', () => {
     await page.locator('select[name="availability_monday"]').selectOption('available')
     await page.locator('input[name="start_time_monday"]').fill('10:00')
     await page.locator('input[name="end_time_monday"]').fill('11:00')
-    await page.locator('textarea[name="exceptionDates"]').fill('2026-11-10\n2026-11-11')
+    await page.locator('textarea[name="exceptionDates"]').fill('2030-11-10\n2030-11-11')
     // Ensure other weekdays are explicitly set to unavailable so the form
     // submission only saves the monday availability we intend to test.
     const otherDays = ['tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
@@ -214,7 +214,7 @@ test.describe('user profile page', () => {
     expect(savedPreferences).toEqual(expect.objectContaining({
       dailyMax: 2,
       duration: 45,
-      exceptionDates: ['2026-11-10', '2026-11-11'],
+      exceptionDates: ['2030-11-10', '2030-11-11'],
       maxStudents: 3,
       minStudents: 1,
       username: LECTURER_USERNAME,

--- a/tests/integration/user_profile_page.test.js
+++ b/tests/integration/user_profile_page.test.js
@@ -223,7 +223,7 @@ describe('user profile integration flow', () => {
         availability_monday: 'available',
         start_time_monday: '10:00',
         end_time_monday: '11:00',
-        exceptionDates: '2026-11-10\n2026-11-11'
+        exceptionDates: '2030-11-10\n2030-11-11'
       }),
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
@@ -240,7 +240,7 @@ describe('user profile integration flow', () => {
     expect(savedPreferences).toEqual(expect.objectContaining({
       dailyMax: 2,
       duration: 45,
-      exceptionDates: ['2026-11-10', '2026-11-11'],
+      exceptionDates: ['2030-11-10', '2030-11-11'],
       maxStudents: 3,
       minStudents: 1,
       username: LECTURER_USERNAME,

--- a/tests/unit/models/consultation_db.test.js
+++ b/tests/unit/models/consultation_db.test.js
@@ -53,7 +53,7 @@ describe('consultation database operations', () => {
     const consultation = {
       attendees: ['morris'],
       capacity: 1,
-      datetime: '2026-05-04T09:00',
+      datetime: '2030-05-04T09:00',
       lecturerId: 'lecturer1',
       organiserId: 'morris',
       title: 'Project check-in'
@@ -72,14 +72,14 @@ describe('consultation database operations', () => {
     const toArray = jest.fn().mockResolvedValue([{ title: 'Project check-in' }])
     mockConsultationCollection.find.mockReturnValue({ toArray })
 
-    const result = await listConsultationsForLecturerOnDate('lecturer1', '2026-05-04')
+    const result = await listConsultationsForLecturerOnDate('lecturer1', '2030-05-04')
 
     expect(getCollection).toHaveBeenCalledWith('Consultation')
     expect(mockConsultationCollection.find).toHaveBeenCalledWith({
       lecturerId: 'lecturer1',
       datetime: {
-        $gte: '2026-05-04T00:00',
-        $lt: '2026-05-04T23:59~'
+        $gte: '2030-05-04T00:00',
+        $lt: '2030-05-04T23:59~'
       }
     })
     expect(toArray).toHaveBeenCalledTimes(1)
@@ -145,10 +145,10 @@ describe('consultation database operations', () => {
     const toArray = jest.fn().mockResolvedValue([])
     mockConsultationCollection.find.mockReturnValue({ toArray })
 
-    await searchConsultationsForStudent({ username: 'student1', date: '2026-05-04' })
+    await searchConsultationsForStudent({ username: 'student1', date: '2030-05-04' })
 
     expect(mockConsultationCollection.find).toHaveBeenCalledWith({
-      datetime: { $gte: '2026-05-04T00:00', $lt: '2026-05-04T23:59~' }
+      datetime: { $gte: '2030-05-04T00:00', $lt: '2030-05-04T23:59~' }
     })
   })
 
@@ -156,9 +156,9 @@ describe('consultation database operations', () => {
     const toArray = jest.fn().mockResolvedValue([])
     mockConsultationCollection.find.mockReturnValue({ toArray })
 
-    await searchConsultationsForStudent({ username: 'student1', date: '2026-05-04', time: '09:00' })
+    await searchConsultationsForStudent({ username: 'student1', date: '2030-05-04', time: '09:00' })
 
-    expect(mockConsultationCollection.find).toHaveBeenCalledWith({ datetime: '2026-05-04T09:00' })
+    expect(mockConsultationCollection.find).toHaveBeenCalledWith({ datetime: '2030-05-04T09:00' })
   })
 
   describe('getConsultationsForCalendar', () => {

--- a/tests/unit/models/lecturer_availability_db.test.js
+++ b/tests/unit/models/lecturer_availability_db.test.js
@@ -57,7 +57,7 @@ describe('lecturer availability database operations', () => {
         { day: 'monday', startTime: '09:00', endTime: '12:00' },
         { day: 'wednesday', startTime: '13:00', endTime: '16:00' }
       ],
-      exceptionDates: ['2026-05-01', '2026-05-08']
+      exceptionDates: ['2030-05-01', '2030-05-08']
     })
 
     expect(mockCollection.updateOne).toHaveBeenCalledWith(
@@ -69,7 +69,7 @@ describe('lecturer availability database operations', () => {
             { day: 'monday', startTime: '09:00', endTime: '12:00' },
             { day: 'wednesday', startTime: '13:00', endTime: '16:00' }
           ],
-          exceptionDates: ['2026-05-01', '2026-05-08']
+          exceptionDates: ['2030-05-01', '2030-05-08']
         }
       },
       { upsert: true }
@@ -121,7 +121,7 @@ describe('lecturer availability database operations', () => {
         duration: 30,
         dailyMax: 4,
         weeklyAvailability: [{ day: 'monday', startTime: '09:00', endTime: '12:00' }],
-        exceptionDates: ['2026-12-25']
+        exceptionDates: ['2030-12-25']
       }
 
       expect(() => validatePreferences(prefs)).not.toThrow()

--- a/tests/unit/routes/consultations.test.js
+++ b/tests/unit/routes/consultations.test.js
@@ -91,6 +91,7 @@ const createServer = async function () {
 describe('consultations route', () => {
   let baseUrl
   let server
+  const MONDAY_DATETIME = '2030-05-06T09:00'
 
   beforeAll(async () => {
     server = await createServer()
@@ -159,7 +160,7 @@ describe('consultations route', () => {
   test('creates a consultation and redirects to home', async () => {
     const response = await fetch(`${baseUrl}/consultations`, {
       body: encodeForm({
-        datetime: '2026-05-04T09:00',
+        datetime: MONDAY_DATETIME,
         lecturerId: 'lecturer1',
         title: 'Project check-in'
       }),
@@ -176,7 +177,7 @@ describe('consultations route', () => {
     expect(addConsultation).toHaveBeenCalledWith({
       attendees: ['morris'],
       capacity: 1,
-      datetime: '2026-05-04T09:00',
+      datetime: MONDAY_DATETIME,
       lecturerId: 'lecturer1',
       organiserId: 'morris',
       title: 'Project check-in'
@@ -192,7 +193,7 @@ describe('consultations route', () => {
 
     const response = await fetch(`${baseUrl}/consultations`, {
       body: encodeForm({
-        datetime: '2026-05-04T09:00',
+        datetime: MONDAY_DATETIME,
         lecturerId: 'lecturer2',
         title: 'Project check-in'
       }),
@@ -232,7 +233,7 @@ describe('consultations route', () => {
 
     const response = await fetch(`${baseUrl}/consultations`, {
       body: encodeForm({
-        datetime: '2026-05-04T09:00',
+        datetime: MONDAY_DATETIME,
         lecturerId: 'lecturer1',
         title: 'Project check-in'
       }),
@@ -253,7 +254,7 @@ describe('consultations route', () => {
 
     const response = await fetch(`${baseUrl}/consultations`, {
       body: encodeForm({
-        datetime: '2026-05-04T09:00',
+        datetime: MONDAY_DATETIME,
         lecturerId: 'lecturer1',
         title: 'Project check-in'
       }),
@@ -274,7 +275,7 @@ describe('consultations route', () => {
 
     const response = await fetch(`${baseUrl}/consultations`, {
       body: encodeForm({
-        datetime: '2026-05-04T09:00',
+        datetime: MONDAY_DATETIME,
         lecturerId: 'lecturer1',
         title: 'Project check-in'
       }),

--- a/tests/unit/routes/join_consultation.test.js
+++ b/tests/unit/routes/join_consultation.test.js
@@ -86,6 +86,7 @@ const createServer = async function () {
 describe('join consultation route', () => {
   let baseUrl
   let server
+  const MONDAY = '2030-05-06'
 
   const MONDAY_AVAILABILITY = {
     duration: 60,
@@ -145,11 +146,11 @@ describe('join consultation route', () => {
   })
 
   test('passes the date filter to searchConsultationsForStudent', async () => {
-    const response = await fetch(`${baseUrl}/join_consultation?date=2026-05-04`)
+    const response = await fetch(`${baseUrl}/join_consultation?date=${MONDAY}`)
 
     expect(response.status).toBe(200)
     expect(searchConsultationsForStudent).toHaveBeenCalledWith({
-      date: '2026-05-04',
+      date: MONDAY,
       lecturerId: '',
       time: '',
       username: 'morris'
@@ -157,18 +158,18 @@ describe('join consultation route', () => {
   })
 
   test('shows the create empty state when no consultations are found for a valid lecturer and date', async () => {
-    const response = await fetch(`${baseUrl}/join_consultation?lecturerId=lecturer1&date=2026-05-04`)
+    const response = await fetch(`${baseUrl}/join_consultation?lecturerId=lecturer1&date=${MONDAY}`)
     const body = await response.text()
 
     expect(response.status).toBe(200)
     expect(getLecturerAvailability).toHaveBeenCalledWith('lecturer1')
     expect(body).toContain('No matching consultations')
     expect(body).toContain('lecturerId=lecturer1')
-    expect(body).toContain('date=2026-05-04')
+    expect(body).toContain(`date=${MONDAY}`)
   })
 
   test('includes the time in the create link when a time filter is provided', async () => {
-    const response = await fetch(`${baseUrl}/join_consultation?lecturerId=lecturer1&date=2026-05-04&time=09%3A00`)
+    const response = await fetch(`${baseUrl}/join_consultation?lecturerId=lecturer1&date=${MONDAY}&time=09%3A00`)
     const body = await response.text()
 
     expect(response.status).toBe(200)
@@ -176,7 +177,7 @@ describe('join consultation route', () => {
   })
 
   test('shows the violation empty state when the time is outside the lecturer schedule', async () => {
-    const response = await fetch(`${baseUrl}/join_consultation?lecturerId=lecturer1&date=2026-05-04&time=13%3A00`)
+    const response = await fetch(`${baseUrl}/join_consultation?lecturerId=lecturer1&date=${MONDAY}&time=13%3A00`)
     const body = await response.text()
 
     expect(response.status).toBe(200)
@@ -184,7 +185,7 @@ describe('join consultation route', () => {
   })
 
   test('does not check availability when lecturerId is not provided', async () => {
-    const response = await fetch(`${baseUrl}/join_consultation?date=2026-05-04`)
+    const response = await fetch(`${baseUrl}/join_consultation?date=${MONDAY}`)
 
     expect(response.status).toBe(200)
     expect(getLecturerAvailability).not.toHaveBeenCalled()

--- a/tests/unit/services/consultation_availability_validation.test.js
+++ b/tests/unit/services/consultation_availability_validation.test.js
@@ -6,6 +6,10 @@ const {
 } = require('../../../src/services/consultation_availability_validation')
 
 describe('consultation availability validation', () => {
+  const MONDAY_DATE = '2030-05-06'
+  const TUESDAY_DATE = '2030-05-07'
+  const SUNDAY_DATE = '2030-05-12'
+
   const baseAvailability = {
     dailyMax: 2,
     duration: 60,
@@ -20,7 +24,7 @@ describe('consultation availability validation', () => {
   test('returns invalid when lecturer availability is missing', () => {
     expect(validateLecturerAvailability({
       availability: null,
-      date: '2026-05-04',
+      date: MONDAY_DATE,
       endTime: '10:00',
       scheduledConsultations: [],
       startTime: '09:00'
@@ -32,8 +36,8 @@ describe('consultation availability validation', () => {
 
   test('returns invalid when the selected date is an exception date', () => {
     expect(validateLecturerAvailability({
-      availability: { ...baseAvailability, exceptionDates: ['2026-05-04'] },
-      date: '2026-05-04',
+      availability: { ...baseAvailability, exceptionDates: [MONDAY_DATE] },
+      date: MONDAY_DATE,
       endTime: '10:00',
       scheduledConsultations: [],
       startTime: '09:00'
@@ -46,7 +50,7 @@ describe('consultation availability validation', () => {
   test('returns invalid when the selected time is outside the weekly slot', () => {
     expect(validateLecturerAvailability({
       availability: baseAvailability,
-      date: '2026-05-04',
+      date: MONDAY_DATE,
       endTime: '12:30',
       scheduledConsultations: [],
       startTime: '11:30'
@@ -59,9 +63,9 @@ describe('consultation availability validation', () => {
   test('returns invalid when the lecturer has reached the daily limit', () => {
     expect(validateLecturerAvailability({
       availability: baseAvailability,
-      date: '2026-05-04',
+      date: MONDAY_DATE,
       endTime: '11:00',
-      scheduledConsultations: [{ datetime: '2026-05-04T08:00' }, { datetime: '2026-05-04T10:00' }],
+      scheduledConsultations: [{ datetime: `${MONDAY_DATE}T08:00` }, { datetime: `${MONDAY_DATE}T10:00` }],
       startTime: '10:00'
     })).toEqual({
       error: 'This lecturer has reached their consultation limit for the selected date.',
@@ -72,7 +76,7 @@ describe('consultation availability validation', () => {
   test('returns valid when the requested consultation fits lecturer availability', () => {
     expect(validateLecturerAvailability({
       availability: baseAvailability,
-      date: '2026-05-04',
+      date: MONDAY_DATE,
       endTime: '10:00',
       scheduledConsultations: [],
       startTime: '09:00'
@@ -85,7 +89,7 @@ describe('consultation availability validation', () => {
   const { findOverlappingConsultation } = require('../../../src/services/consultation_availability_validation')
 
   test('detects overlapping consultation when times overlap', () => {
-    const scheduled = [{ datetime: '2026-05-04T10:00' }]
+    const scheduled = [{ datetime: '2030-05-04T10:00' }]
 
     const conflict = findOverlappingConsultation({
       scheduledConsultations: scheduled,
@@ -97,7 +101,7 @@ describe('consultation availability validation', () => {
   })
 
   test('allows back-to-back consultations when end equals start', () => {
-    const scheduled = [{ datetime: '2026-05-04T10:00' }]
+    const scheduled = [{ datetime: '2030-05-04T10:00' }]
 
     const conflict = findOverlappingConsultation({
       scheduledConsultations: scheduled,
@@ -109,7 +113,7 @@ describe('consultation availability validation', () => {
   })
 
   test('ignores cancelled consultations with boolean flag', () => {
-    const scheduled = [{ datetime: '2026-05-04T10:00', cancelled: true }]
+    const scheduled = [{ datetime: '2030-05-04T10:00', cancelled: true }]
 
     const conflict = findOverlappingConsultation({
       scheduledConsultations: scheduled,
@@ -121,7 +125,7 @@ describe('consultation availability validation', () => {
   })
 
   test('ignores cancelled consultations with status string', () => {
-    const scheduled = [{ datetime: '2026-05-04T10:00', status: 'cancelled' }]
+    const scheduled = [{ datetime: '2030-05-04T10:00', status: 'cancelled' }]
 
     const conflict = findOverlappingConsultation({
       scheduledConsultations: scheduled,
@@ -139,11 +143,11 @@ describe('consultation availability validation', () => {
   })
 
   test('getWeekdayFromIso returns the weekday for a known Monday date', () => {
-    expect(getWeekdayFromIso('2026-05-04')).toBe('monday')
+    expect(getWeekdayFromIso(MONDAY_DATE)).toBe('monday')
   })
 
   test('getWeekdayFromIso returns the weekday for a known Sunday date', () => {
-    expect(getWeekdayFromIso('2026-05-10')).toBe('sunday')
+    expect(getWeekdayFromIso(SUNDAY_DATE)).toBe('sunday')
   })
 
   test('getWeekdayFromIso returns empty string for an invalid date', () => {
@@ -156,8 +160,8 @@ describe('consultation availability validation', () => {
       exceptionDates: [],
       weeklyAvailability: [{ day: 'monday', startTime: '08:00', endTime: '12:00' }]
     }
-    const MONDAY = '2026-05-04'
-    const TUESDAY = '2026-05-05'
+    const MONDAY = MONDAY_DATE
+    const TUESDAY = TUESDAY_DATE
 
     test('returns false when availability is null', () => {
       expect(isDateAvailableForLecturer(null, MONDAY, '')).toBe(false)

--- a/tests/unit/utils/calendar.test.js
+++ b/tests/unit/utils/calendar.test.js
@@ -40,7 +40,7 @@ const findCalendarDay = function (calendar, dayNumber) {
 
 describe('calendar utility', () => {
   test('marks weekly availability days as available', function () {
-    const year = 2026
+    const year = 2030
     const month = 4
     const firstMonday = findFirstDayNumberForWeekday(year, month, 1)
     const calendar = buildCurrentMonthCalendar(new Date(year, month, 15), {
@@ -56,7 +56,7 @@ describe('calendar utility', () => {
   })
 
   test('marks exception dates as unavailable even when the weekday is usually available', function () {
-    const year = 2026
+    const year = 2030
     const month = 4
     const firstMonday = findFirstDayNumberForWeekday(year, month, 1)
     const calendar = buildCurrentMonthCalendar(new Date(year, month, 15), {


### PR DESCRIPTION
Changed all dates to use 2030 instead of 2026 (except for the single test that checks a past date cannot be added to the db)

closes issue #57 