### PR TITLE
Lecturer roster

### DIFF
--- a/src/models/consultation_db.js
+++ b/src/models/consultation_db.js
@@ -25,6 +25,16 @@ const buildDisplayName = function (user, fallback) {
   return fullName || fallback || ''
 }
 
+const buildAttendeeRoster = function (attendees, usersByUsername) {
+  if (!Array.isArray(attendees) || attendees.length === 0) {
+    return []
+  }
+
+  return attendees.map(function (username) {
+    return buildDisplayName(usersByUsername.get(username), username)
+  })
+}
+
 const buildConsultationTime = function (datetime, duration) {
   const startTime = datetime?.slice(11, 16) || ''
 
@@ -78,12 +88,14 @@ const getUpcomingConsultationsForLecturer = async function (lecturerId) {
     return []
   }
 
-  const organiserIds = [...new Set(consultations.map(function (consultation) {
-    return consultation.organiserId
+  const userIds = [...new Set(consultations.flatMap(function (consultation) {
+    const attendees = Array.isArray(consultation.attendees) ? consultation.attendees : []
+
+    return [consultation.organiserId, ...attendees]
   }).filter(Boolean))]
 
   const [users, availabilities] = await Promise.all([
-    usersCollection().find({ username: { $in: organiserIds } }).toArray(),
+    usersCollection().find({ username: { $in: userIds } }).toArray(),
     getCollection(AVAILABILITY_COLLECTION_NAME).find({ username: lecturerId }).toArray()
   ])
 
@@ -103,6 +115,7 @@ const getUpcomingConsultationsForLecturer = async function (lecturerId) {
       id: consultation._id.toString(),
       name: consultation.title || 'Untitled consultation',
       organiser: buildDisplayName(usersByUsername.get(consultation.organiserId), consultation.organiserId),
+      roster: buildAttendeeRoster(consultation.attendees, usersByUsername),
       time: buildConsultationTime(consultation.datetime, lecturerAvailability?.duration)
     }
   })

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -453,6 +453,30 @@ a {
   color: var(--color-secondary);
 }
 
+.dashboard_roster {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--color-border);
+}
+
+.dashboard_roster_title {
+  margin: 0;
+}
+
+.dashboard_roster_list {
+  margin: 12px 0 0;
+  padding-left: 20px;
+}
+
+.dashboard_roster_list li + li {
+  margin-top: 8px;
+}
+
+.dashboard_roster_empty {
+  margin: 12px 0 0;
+  color: var(--color-secondary);
+}
+
 .consultation_preferences_form h3 {
   margin: 0;
   text-align: center;

--- a/src/views/scheduled_consultations.ejs
+++ b/src/views/scheduled_consultations.ejs
@@ -26,11 +26,24 @@
         <% } else { %>
           <div class="dashboard_consultations">
             <% consultations.forEach(function (consultation) { %>
+              <% const roster = Array.isArray(consultation.roster) ? consultation.roster : [] %>
               <article class="dashboard_consultation_card">
                 <h3><%= consultation.name %></h3>
                 <p class="dashboard_consultation_meta"><strong>Organiser:</strong> <%= consultation.organiser %></p>
                 <p class="dashboard_consultation_meta"><strong>Date:</strong> <%= consultation.date %></p>
                 <p class="dashboard_consultation_meta"><strong>Time:</strong> <%= consultation.time %></p>
+                <section class="dashboard_roster">
+                  <h4 class="dashboard_roster_title">Attendee roster</h4>
+                  <% if (roster.length === 0) { %>
+                    <p class="dashboard_roster_empty">No confirmed students booked for this session yet.</p>
+                  <% } else { %>
+                    <ul class="dashboard_roster_list">
+                      <% roster.forEach(function (attendee) { %>
+                        <li><%= attendee %></li>
+                      <% }) %>
+                    </ul>
+                  <% } %>
+                </section>
               </article>
             <% }) %>
           </div>

--- a/tests/E2E/lecturer_dashboard.js
+++ b/tests/E2E/lecturer_dashboard.js
@@ -3,11 +3,11 @@ const { test, expect } = require('@playwright/test')
 const { connectToDatabase, closeDatabaseConnection, getCollection } = require('../../src/models/db')
 require('dotenv').config({ path: path.resolve(__dirname, '../../.env'), quiet: true })
 
+const TEST_ID = `${process.pid}${Date.now()}`
 const LECTURER_PASSWORD = 'password1'
 const LECTURER_USERNAME = 'user1'
 const STUDENT_PASSWORD = 'password'
 const STUDENT_USERNAME = 'user'
-const TEST_ID = `${process.pid}${Date.now()}`
 const TEST_TITLE_PREFIX = 'lecturer-dashboard-e2e-'
 
 /**
@@ -72,9 +72,18 @@ test.describe('lecturer dashboard E2E', () => {
     const datetime = getFutureDatetime(24)
 
     await connectToDatabase()
+    const users = getCollection('User')
+    const seededStudent = await users.findOne({ username: 'user' })
+
+    if (!seededStudent) {
+      throw new Error('Seeded student user for lecturer dashboard E2E tests was not found.')
+    }
+
+    const rosterAttendeeName = `${seededStudent.firstName || ''} ${seededStudent.lastName || ''}`.trim() || seededStudent.username
+
     await getCollection('Consultation').insertMany([
       {
-        attendees: ['student1'],
+        attendees: [seededStudent.username],
         capacity: 1,
         datetime,
         lecturerId: LECTURER_USERNAME,
@@ -108,6 +117,8 @@ test.describe('lecturer dashboard E2E', () => {
     await expect(consultationCard).toContainText('dashboard-student')
     await expect(consultationCard).toContainText(datetime.slice(0, 10))
     await expect(consultationCard).toContainText(datetime.slice(11, 16))
+    await expect(consultationCard).toContainText('Attendee roster')
+    await expect(consultationCard).toContainText(rosterAttendeeName)
 
     await expect(calendarNote).toBeVisible()
     await expect(calendarNote).toContainText(datetime.slice(11, 16))

--- a/tests/integration/lecturer_login.test.js
+++ b/tests/integration/lecturer_login.test.js
@@ -173,9 +173,18 @@ describe('lecturer login integration flow', () => {
     const visibleDatetime = getRelativeDatetime(24)
 
     await connectToDatabase()
+    const users = getCollection('User')
+    const seededStudent = await users.findOne({ username: 'user' })
+
+    if (!seededStudent) {
+      throw new Error('Seeded student user for lecturer dashboard integration tests was not found.')
+    }
+
+    const rosterAttendeeName = `${seededStudent.firstName || ''} ${seededStudent.lastName || ''}`.trim() || seededStudent.username
+
     await getCollection('Consultation').insertMany([
       {
-        attendees: ['student1'],
+        attendees: [seededStudent.username],
         capacity: 1,
         datetime: visibleDatetime,
         lecturerId: USERNAME,
@@ -225,6 +234,8 @@ describe('lecturer login integration flow', () => {
     expect(body).toContain('dashboard-student')
     expect(body).toContain(visibleDatetime.slice(0, 10))
     expect(body).toContain(visibleDatetime.slice(11, 16))
+    expect(body).toContain('Attendee roster')
+    expect(body).toContain(rosterAttendeeName)
     expect(body).toContain('calendar_table')
     expect(body).toContain('calendar_day_note_dashboard')
     expect(body).not.toContain(otherLecturerTitle)

--- a/tests/unit/models/consultation_db.test.js
+++ b/tests/unit/models/consultation_db.test.js
@@ -107,6 +107,7 @@ describe('consultation database operations', () => {
       toArray: jest.fn().mockResolvedValue([
         {
           _id: secondId,
+          attendees: ['student4'],
           datetime: laterFutureDate,
           lecturerId: 'lecturer1',
           organiserId: 'student2',
@@ -114,6 +115,7 @@ describe('consultation database operations', () => {
         },
         {
           _id: firstId,
+          attendees: ['student1', 'student3'],
           datetime: futureDate,
           lecturerId: 'lecturer1',
           organiserId: 'student1',
@@ -121,6 +123,7 @@ describe('consultation database operations', () => {
         },
         {
           _id: new ObjectId(),
+          attendees: ['student5'],
           datetime: pastDate,
           lecturerId: 'lecturer1',
           organiserId: 'student3',
@@ -130,7 +133,8 @@ describe('consultation database operations', () => {
     })
     mockUserCollection.find.mockReturnValue({
       toArray: jest.fn().mockResolvedValue([
-        { username: 'student1', firstName: 'Morris', lastName: 'Molefe' }
+        { username: 'student1', firstName: 'Morris', lastName: 'Molefe' },
+        { username: 'student3', firstName: 'Sam', lastName: 'Nkosi' }
       ])
     })
     mockLecturerAvailabilityCollection.find.mockReturnValue({
@@ -142,12 +146,18 @@ describe('consultation database operations', () => {
     const result = await getUpcomingConsultationsForLecturer('lecturer1')
 
     expect(mockConsultationCollection.find).toHaveBeenCalledWith({ lecturerId: 'lecturer1' })
+    expect(mockUserCollection.find).toHaveBeenCalledWith({
+      username: {
+        $in: expect.arrayContaining(['student1', 'student2', 'student3', 'student4', 'student5'])
+      }
+    })
     expect(result).toEqual([
       {
         date: futureDate.slice(0, 10),
         id: firstId.toString(),
         name: 'Earlier consultation',
         organiser: 'Morris Molefe',
+        roster: ['Morris Molefe', 'Sam Nkosi'],
         time: '09:00 to 09:30'
       },
       {
@@ -155,6 +165,7 @@ describe('consultation database operations', () => {
         id: secondId.toString(),
         name: 'Later consultation',
         organiser: 'student2',
+        roster: ['student4'],
         time: '11:30 to 12:00'
       }
     ])

--- a/tests/unit/routes/home.test.js
+++ b/tests/unit/routes/home.test.js
@@ -327,6 +327,7 @@ describe('home route', () => {
         id: 'consultation-1',
         name: 'Project check-in',
         organiser: 'morris',
+        roster: ['Alice Smith', 'Brian Molefe'],
         time: '09:00 to 09:30'
       }
     ])
@@ -355,11 +356,43 @@ describe('home route', () => {
     expect(body).toContain('morris')
     expect(body).toContain('2030-05-04')
     expect(body).toContain('09:00 to 09:30')
+    expect(body).toContain('Attendee roster')
+    expect(body).toContain('Alice Smith')
+    expect(body).toContain('Brian Molefe')
     expect(body).toContain('calendar_table')
     expect(body).toContain('calendar_day_note_dashboard')
     expect(body).toContain('href="/home"')
     expect(connectToDatabase).toHaveBeenCalledTimes(1)
     expect(getUpcomingConsultationsForLecturer).toHaveBeenCalledWith('lecturer1')
+  })
+
+  test('Renders an empty roster message when a consultation has no confirmed attendees', async () => {
+    getUpcomingConsultationsForLecturer.mockResolvedValueOnce([
+      {
+        date: '2030-05-04',
+        id: 'consultation-1',
+        name: 'Project check-in',
+        organiser: 'morris',
+        roster: [],
+        time: '09:00 to 09:30'
+      }
+    ])
+
+    const { sessionCookie } = await loginAs({
+      role: 'lecturer',
+      username: 'lecturer1'
+    })
+
+    const response = await fetch(`${baseUrl}/scheduled_consultations`, {
+      headers: {
+        cookie: sessionCookie
+      }
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('No confirmed students booked for this session yet.')
   })
 
   test('Renders an empty lecturer dashboard when there are no upcoming consultations', async () => {


### PR DESCRIPTION
Close #56 

**Summary:** Add an attendee roster to the lecturer dashboard so lecturers can see confirmed students for each upcoming consultation. This includes server-side roster data, dashboard rendering, empty-state handling, and test coverage.

**Key Changes:**

- Added roster data to lecturer dashboard consultations by resolving attendee usernames to full names, with username fallback.
- Rendered an **Attendee roster** section on each consultation card, grouped by the existing topic, date, and time display.
- Added an empty-state message when a consultation has no confirmed students booked.
- Added unit, integration, and E2E coverage for the roster flow.

**Acceptance:**

- Lecturers can see confirmed attendees for their own upcoming consultations.
- Attendees are shown by full name when available.
- Empty rosters show a clear message when no students are booked.
- Non-lecturers still cannot access the lecturer dashboard.

**How to test locally:**

- `npm test`
- `npm run lint`
- `npm run test:unit -- tests/unit/models/consultation_db.test.js --runInBand`
- `npm run test:unit -- tests/unit/routes/home.test.js --runInBand`
- `npm run test:integration:web -- tests/integration/lecturer_login.test.js --runInBand`
- `npm run test:e2e -- tests/E2E/lecturer_dashboard.js`

**Notes:**

- The roster uses the existing `attendees` field as the source of confirmed bookings.
- DB-backed integration and E2E tests require a writable MongoDB test database.

Part of #37 
finally closes #37