### PR TITLE
View logs

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -14,6 +14,8 @@ module.exports = defineConfig({
     command: 'node src/app.js',
     env: {
       ...process.env,
+      DISABLE_ACTION_LOG_DB_WRITES: 'true',
+      NODE_ENV: 'test',
       PORT: '4173',
       SESSION_SECRET: process.env.SESSION_SECRET || 'playwright-session-secret'
     },

--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,7 @@ const consultationsRouter = require('./routes/consultations')
 const homeRouter = require('./routes/home')
 const scheduleConsultationRouter = require('./routes/schedule_consultation')
 const scheduledConsultationsRouter = require('./routes/scheduled_consultations')
+const logsRouter = require('./routes/logs')
 const userProfileRouter = require('./routes/user_profile')
 const app = express()
 const PORT = process.env.PORT || 8080
@@ -37,6 +38,7 @@ app.use('/home', requireAuthentication, homeRouter)
 app.use('/join_consultation', requireAuthentication, joinConsultationRouter)
 app.use('/schedule_consultation', requireAuthentication, scheduleConsultationRouter)
 app.use('/scheduled_consultations', requireAuthentication, scheduledConsultationsRouter)
+app.use('/logs', requireAuthentication, logsRouter)
 app.use('/user_profile', requireAuthentication, userProfileRouter)
 // entry-point is login page. This can be changed when authentication between pages is added
 

--- a/src/middleware/action_logger.js
+++ b/src/middleware/action_logger.js
@@ -61,13 +61,13 @@ const ACTION_MAP = [
     method: 'GET',
     pattern: /^\/institutions\/universities$/,
     label: function (req, res) {
-      if (res.statusCode !== 302) {
-        if (res.statusCode === 500) {
-          return 'Could not check Universities.'
-        }
-        return 'University not found in search results'
+      if (res.statusCode === 500) {
+        return 'Could not check Universities.'
       }
       const university = req.query.query?.trim() || ''
+      if (!university) {
+        return 'Searched Universities.'
+      }
       return `Searched Universities for ${university}.`
     }
   },
@@ -75,13 +75,13 @@ const ACTION_MAP = [
     method: 'GET',
     pattern: /^\/institutions\/faculties$/,
     label: function (req, res) {
-      if (res.statusCode !== 302) {
-        if (res.statusCode === 500) {
-          return 'Could not check Faculties.'
-        }
-        return 'Faculty not found in search results'
+      if (res.statusCode === 500) {
+        return 'Could not check Faculties.'
       }
       const faculty = req.query.query?.trim() || ''
+      if (!faculty) {
+        return 'Searched Faculties.'
+      }
       return `Searched Faculties for ${faculty}.`
     }
   },
@@ -89,13 +89,13 @@ const ACTION_MAP = [
     method: 'GET',
     pattern: /^\/institutions\/schools$/,
     label: function (req, res) {
-      if (res.statusCode !== 302) {
-        if (res.statusCode === 500) {
-          return 'Could not check Schools.'
-        }
-        return 'School not found in search results'
+      if (res.statusCode === 500) {
+        return 'Could not check Schools.'
       }
       const school = req.query.query?.trim() || ''
+      if (!school) {
+        return 'Searched Schools.'
+      }
       return `Searched Schools for ${school}.`
     }
   }

--- a/src/middleware/action_logger.js
+++ b/src/middleware/action_logger.js
@@ -1,3 +1,6 @@
+const { connectToDatabase } = require('../models/db')
+const { addLog } = require('../models/logs_db')
+
 const ACTION_MAP = [
   { method: 'GET', pattern: /^\/login$/, label: 'Viewed Login page' },
   { method: 'POST', pattern: /^\/login$/, label: 'Logged in' },
@@ -119,19 +122,63 @@ const formatTimestamp = function () {
          `${pad(rightNow.getHours())}:${pad(rightNow.getMinutes())}:${pad(rightNow.getSeconds())}`
 }
 
+const shouldSkipDatabaseWrite = function () {
+  return process.env.NODE_ENV === 'test' || process.env.DISABLE_ACTION_LOG_DB_WRITES === 'true'
+}
+
 const actionLogger = function (req, res, next) {
   res.on('finish', function () {
     const cleanPath = req.originalUrl.split('?')[0]
+
+    // Skip logging for the logs page itself
+    if (req.method === 'GET' && cleanPath === '/logs') {
+      return
+    }
+
     const label = getActionLabel(req.method, cleanPath, req, res)
     if (!label) {
       return
     }
     const sessionUser = req.session && req.session.user
-    const identity = sessionUser
-      ? `${sessionUser.username} [${sessionUser.role || 'unknown'}]`
+    const username = sessionUser
+      ? sessionUser.username
       : 'anonymous'
+    const role = sessionUser ? (sessionUser.role || 'unknown') : 'unknown'
+    const identity = `${username} [${role}]`
+    const logMessage = `[${formatTimestamp()}] ${identity} | ${label} | HTTP ${res.statusCode}`
 
-    console.log(`[${formatTimestamp()}] ${identity} | ${label} | HTTP ${res.statusCode}`)
+    console.log(logMessage)
+
+    if (shouldSkipDatabaseWrite()) {
+      return
+    }
+
+    // Save to database
+    try {
+      connectToDatabase().then(function () {
+        const now = new Date()
+        const pad = (n) => String(n).padStart(2, '0')
+        const date = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+        const time = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`
+
+        addLog({
+          date,
+          time,
+          username,
+          label,
+          httpCode: res.statusCode
+        }).catch(function (error) {
+          // Silently fail if database write fails - don't interrupt response
+          console.error('Failed to write log to database:', error.message)
+        })
+      }).catch(function (error) {
+        // Silently fail if database connection fails
+        console.error('Failed to connect to database for logging:', error.message)
+      })
+    } catch (error) {
+      // Silently fail if any error occurs during logging
+      console.error('Error during log write:', error.message)
+    }
   })
   next()
 }

--- a/src/models/logs_db.js
+++ b/src/models/logs_db.js
@@ -31,7 +31,33 @@ const getAllLogs = async function () {
     .toArray()
 }
 
+/**
+ * Retrieves a page of logs sorted by date and time descending.
+ * @param {number} [page=1] - One-based page index.
+ * @param {number} [limit=50] - Maximum logs to return per page.
+ * @returns {Promise<{logs: Array<object>, hasNextPage: boolean}>} Log page data.
+ */
+const getLogsPage = async function (page = 1, limit = 50) {
+  const safePage = Number.isInteger(page) && page > 0 ? page : 1
+  const safeLimit = Number.isInteger(limit) && limit > 0 ? limit : 50
+  const skip = (safePage - 1) * safeLimit
+  const collection = await getCollection(LOGS_COLLECTION)
+
+  const results = await collection
+    .find({})
+    .sort({ date: -1, time: -1 })
+    .skip(skip)
+    .limit(safeLimit + 1)
+    .toArray()
+
+  return {
+    logs: results.slice(0, safeLimit),
+    hasNextPage: results.length > safeLimit
+  }
+}
+
 module.exports = {
   addLog,
-  getAllLogs
+  getAllLogs,
+  getLogsPage
 }

--- a/src/models/logs_db.js
+++ b/src/models/logs_db.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const { getCollection } = require('./db')
+
+const LOGS_COLLECTION = 'Logs'
+
+/**
+ * Inserts a log entry into the Logs collection.
+ * @param {object} logEntry - Log entry to insert.
+ * @param {string} logEntry.date - Date in YYYY-MM-DD format.
+ * @param {string} logEntry.time - Time in HH:MM:SS format.
+ * @param {string} logEntry.username - Username or 'anonymous'.
+ * @param {string} logEntry.label - Action description.
+ * @param {number} logEntry.httpCode - HTTP status code.
+ * @returns {Promise<object>} The insert result.
+ */
+const addLog = async function (logEntry) {
+  const collection = await getCollection(LOGS_COLLECTION)
+  return collection.insertOne(logEntry)
+}
+
+/**
+ * Retrieves all logs from the Logs collection, sorted by date and time descending.
+ * @returns {Promise<Array<object>>} Array of log entries.
+ */
+const getAllLogs = async function () {
+  const collection = await getCollection(LOGS_COLLECTION)
+  return collection
+    .find({})
+    .sort({ date: -1, time: -1 })
+    .toArray()
+}
+
+module.exports = {
+  addLog,
+  getAllLogs
+}

--- a/src/routes/consultations.js
+++ b/src/routes/consultations.js
@@ -136,7 +136,7 @@ router.get('/new', async function (req, res) {
   const username = req.session?.user?.username || ''
   const universityId = req.session?.user?.universityId || ''
 
-  if (role !== 'student') {
+  if (role !== 'student' && role !== 'admin') {
     return renderCreateConsultation(res, {
       error: 'Only students can create consultations.',
       statusCode: 403,
@@ -176,7 +176,7 @@ router.post('/', async function (req, res) {
   const organiserId = req.session?.user?.username || ''
   const universityId = req.session?.user?.universityId || ''
 
-  if (role !== 'student') {
+  if (role !== 'student' && role !== 'admin') {
     return renderCreateConsultation(res, {
       consultationTitle,
       error: 'Only students can create consultations.',

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -10,6 +10,7 @@ const { buildCurrentMonthCalendar } = require('../utils/calendar')
 const router = express.Router()
 
 const HOME_TITLES = Object.freeze({
+  admin: 'Admin Home',
   lecturer: 'Lecturer Home',
   student: 'Student Home'
 })
@@ -34,7 +35,7 @@ router.get('/', async (req, res) => {
     }
   }
 
-  if (role !== 'student') {
+  if (role !== 'student' && role !== 'admin') {
     return res.render('home', { title, homeTitle, role, username, calendar, consultationsByDate: {}, lecturers: [], faculties: [], schools: [], query: '', facultyId: '', schoolId: '', page: 1, totalPages: 0 })
   }
 

--- a/src/routes/logs.js
+++ b/src/routes/logs.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const express = require('express')
+
+const router = express.Router()
+
+const renderLogs = function (res, { statusCode = 200, error = '', username = '' } = {}) {
+  return res.status(statusCode).render('logs', {
+    error,
+    title: 'View Logs',
+    username
+  })
+}
+
+router.get('/', (req, res) => {
+  const role = req.session?.user?.role || ''
+  const username = req.session?.user?.username || ''
+
+  if (role !== 'admin') {
+    return renderLogs(res, {
+      error: 'Only the admin can view logs.',
+      statusCode: 403,
+      username
+    })
+  }
+
+  return renderLogs(res, { username })
+})
+
+module.exports = router

--- a/src/routes/logs.js
+++ b/src/routes/logs.js
@@ -1,18 +1,21 @@
 'use strict'
 
 const express = require('express')
+const { connectToDatabase } = require('../models/db')
+const { getAllLogs } = require('../models/logs_db')
 
 const router = express.Router()
 
-const renderLogs = function (res, { statusCode = 200, error = '', username = '' } = {}) {
+const renderLogs = function (res, { statusCode = 200, error = '', username = '', logs = [] } = {}) {
   return res.status(statusCode).render('logs', {
     error,
     title: 'View Logs',
-    username
+    username,
+    logs
   })
 }
 
-router.get('/', (req, res) => {
+router.get('/', async (req, res) => {
   const role = req.session?.user?.role || ''
   const username = req.session?.user?.username || ''
 
@@ -24,7 +27,17 @@ router.get('/', (req, res) => {
     })
   }
 
-  return renderLogs(res, { username })
+  try {
+    await connectToDatabase()
+    const logs = await getAllLogs()
+    return renderLogs(res, { username, logs })
+  } catch (error) {
+    return renderLogs(res, {
+      error: 'Unable to load logs right now.',
+      statusCode: 500,
+      username
+    })
+  }
 })
 
 module.exports = router

--- a/src/routes/logs.js
+++ b/src/routes/logs.js
@@ -2,16 +2,37 @@
 
 const express = require('express')
 const { connectToDatabase } = require('../models/db')
-const { getAllLogs } = require('../models/logs_db')
+const { getLogsPage } = require('../models/logs_db')
 
 const router = express.Router()
+const LOGS_PER_PAGE = 50
 
-const renderLogs = function (res, { statusCode = 200, error = '', username = '', logs = [] } = {}) {
+const parsePageNumber = function (value) {
+  const page = Number.parseInt(value, 10)
+
+  if (!Number.isInteger(page) || page < 1) {
+    return 1
+  }
+
+  return page
+}
+
+const renderLogs = function (res, {
+  statusCode = 200,
+  error = '',
+  username = '',
+  logs = [],
+  page = 1,
+  hasNextPage = false
+} = {}) {
   return res.status(statusCode).render('logs', {
     error,
     title: 'View Logs',
     username,
-    logs
+    logs,
+    page,
+    hasNextPage,
+    hasPreviousPage: page > 1
   })
 }
 
@@ -23,19 +44,23 @@ router.get('/', async (req, res) => {
     return renderLogs(res, {
       error: 'Only the admin can view logs.',
       statusCode: 403,
-      username
+      username,
+      page: 1
     })
   }
 
+  const page = parsePageNumber(req.query.page)
+
   try {
     await connectToDatabase()
-    const logs = await getAllLogs()
-    return renderLogs(res, { username, logs })
+    const { logs, hasNextPage } = await getLogsPage(page, LOGS_PER_PAGE)
+    return renderLogs(res, { username, logs, page, hasNextPage })
   } catch (error) {
     return renderLogs(res, {
       error: 'Unable to load logs right now.',
       statusCode: 500,
-      username
+      username,
+      page
     })
   }
 })

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -19,7 +19,7 @@
       <% } %>
     </header>
 
-    <% if (role === 'student' && username) { %>
+    <% if ((role === 'student' || role === 'admin') && username) { %>
       <section class="home_navigation">
         <h2 class="home_navigation_title">Navigation</h2>
         <p class="home_navigation_text">Choose an option below.</p>
@@ -28,6 +28,9 @@
           <a href="/consultations/new">Create Consultation</a>
           <a href="/join_consultation">Join Consultation</a>
         </div>
+        <% if (role === 'admin') { %>
+          <a href="/logs" style="width: fit-content; margin: 4px auto 0; padding: 8px 14px; background: var(--color-secondary); font-size: 0.92rem;">View Logs</a>
+        <% } %>
       </section>
     <% } else if (role === 'lecturer' && username) { %>
       <section class="home_navigation">
@@ -56,7 +59,7 @@
               <% week.forEach(function (day) { %>
                 <% if (day.isEmpty) { %>
                   <td class="calendar_day calendar_day_empty"></td>
-                <% } else if (role === 'student') { %>
+                <% } else if (role === 'student' || role === 'admin') { %>
                   <% const dayCons = consultationsByDate[day.isoDate] || [] %>
                   <td class="calendar_day">
                     <div class="calendar_day_content">
@@ -84,7 +87,7 @@
       </table>
     </section>
 
-    <% if (role === 'student') { %>
+    <% if (role === 'student' || role === 'admin') { %>
       <h1>Find a Lecturer</h1>
       <section>
         <form id="lecturer_search_form" action="/home" method="get">

--- a/src/views/logs.ejs
+++ b/src/views/logs.ejs
@@ -31,10 +31,38 @@
       color: #64748b;
       font-style: italic;
     }
+    .logs_top_actions {
+      margin-bottom: 12px;
+      text-align: left;
+    }
+    .logs_pagination {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 10px;
+      margin-top: 16px;
+      font-size: 0.95rem;
+    }
+    .logs_pagination_link {
+      color: #1d4ed8;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .logs_pagination_link:hover {
+      text-decoration: underline;
+    }
+    .logs_pagination_current {
+      color: #334155;
+      font-weight: 600;
+    }
   </style>
 </head>
 <body class="page page_home">
   <main class="card card_even_wider text_center">
+    <div class="logs_top_actions">
+      <a class="back_link" href="/home">Back to Home</a>
+    </div>
+
     <header>
       <h1>View Logs</h1>
       <% if (username) { %>
@@ -56,9 +84,17 @@
           <div class="logs_empty">No logs available.</div>
         <% } %>
       </div>
-    <% } %>
 
-    <a class="back_link" href="/home">Back to Home</a>
+      <div class="logs_pagination">
+        <% if (hasPreviousPage) { %>
+          <a class="logs_pagination_link" href="/logs?page=<%= page - 1 %>">Previous</a>
+        <% } %>
+        <span class="logs_pagination_current">Page <%= page %></span>
+        <% if (hasNextPage) { %>
+          <a class="logs_pagination_link" href="/logs?page=<%= page + 1 %>">Next</a>
+        <% } %>
+      </div>
+    <% } %>
   </main>
 </body>
 </html>

--- a/src/views/logs.ejs
+++ b/src/views/logs.ejs
@@ -5,9 +5,36 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title><%= title %></title>
   <link rel="stylesheet" href="/styles/main.css">
+  <style>
+    .logs_container {
+      max-width: 900px;
+      margin: 24px auto 0;
+      text-align: left;
+      background: #f8fafc;
+      border: 1px solid #cbd5e1;
+      border-radius: 8px;
+      padding: 16px;
+      max-height: 600px;
+      overflow-y: auto;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      line-height: 1.6;
+    }
+    .logs_entry {
+      padding: 4px 0;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .logs_entry:last-child {
+      border-bottom: none;
+    }
+    .logs_empty {
+      color: #64748b;
+      font-style: italic;
+    }
+  </style>
 </head>
 <body class="page page_home">
-  <main class="card card_wide text_center">
+  <main class="card card_even_wider text_center">
     <header>
       <h1>View Logs</h1>
       <% if (username) { %>
@@ -18,8 +45,17 @@
     <% if (error) { %>
       <div class="error"><%= error %></div>
     <% } else { %>
-      <p>The application writes action logs to the server console.</p>
-      <p>Use the home page to continue navigating as the admin user.</p>
+      <div class="logs_container">
+        <% if (logs && logs.length > 0) { %>
+          <% logs.forEach(function (log) { %>
+            <div class="logs_entry">
+              [<%= log.date %> <%= log.time %>] <%= log.username %> | <%= log.label %> | HTTP <%= log.httpCode %>
+            </div>
+          <% }) %>
+        <% } else { %>
+          <div class="logs_empty">No logs available.</div>
+        <% } %>
+      </div>
     <% } %>
 
     <a class="back_link" href="/home">Back to Home</a>

--- a/src/views/logs.ejs
+++ b/src/views/logs.ejs
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><%= title %></title>
+  <link rel="stylesheet" href="/styles/main.css">
+</head>
+<body class="page page_home">
+  <main class="card card_wide text_center">
+    <header>
+      <h1>View Logs</h1>
+      <% if (username) { %>
+        <p>Hello <%= username %></p>
+      <% } %>
+    </header>
+
+    <% if (error) { %>
+      <div class="error"><%= error %></div>
+    <% } else { %>
+      <p>The application writes action logs to the server console.</p>
+      <p>Use the home page to continue navigating as the admin user.</p>
+    <% } %>
+
+    <a class="back_link" href="/home">Back to Home</a>
+  </main>
+</body>
+</html>

--- a/tests/E2E/login_page.js
+++ b/tests/E2E/login_page.js
@@ -9,7 +9,7 @@ const USERNAME = 'user'
 test.describe('login page', () => {
   test.skip(!process.env.MONGODB_URI, 'Requires a writable MongoDB test database.')
 
-  test('logs in with the seeded student user and reaches the home page', async ({ page }) => {
+  test('logs in with the seeded admin user and reaches the home page', async ({ page }) => {
     await page.goto('/login')
 
     await page.getByRole('textbox', { name: 'Username' }).fill(USERNAME)
@@ -17,8 +17,8 @@ test.describe('login page', () => {
     await page.getByRole('button', { name: 'Log In' }).click()
 
     await expect(page).toHaveURL(/\/home$/)
-    await expect(page.getByRole('heading', { name: 'Student Home' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Admin Home' })).toBeVisible()
     await expect(page.getByText(`Hello ${USERNAME}`)).toBeVisible()
-    await expect(page.getByText('You are logged in as a student.')).toBeVisible()
+    await expect(page.getByText('You are logged in as a admin.')).toBeVisible()
   })
 })

--- a/tests/integration/student_login.test.js
+++ b/tests/integration/student_login.test.js
@@ -63,7 +63,7 @@ describe('student login integration flow', () => {
     await closeDatabaseConnection()
   })
 
-  RUN_DB_TEST('logs in with the seeded student user and renders student-specific home navigation', async function () {
+  RUN_DB_TEST('logs in with the seeded admin user and renders admin-specific home navigation', async function () {
     const loginResponse = await fetch(`${baseUrl}/login`, {
       body: encodeForm({
         password: PASSWORD,
@@ -90,13 +90,15 @@ describe('student login integration flow', () => {
     const body = await homeResponse.text()
 
     expect(homeResponse.status).toBe(200)
-    expect(body).toContain('<title>Student Home</title>')
+    expect(body).toContain('<title>Admin Home</title>')
     expect(body).toContain(`Hello ${USERNAME}`)
-    expect(body).toContain('You are logged in as a student.')
+    expect(body).toContain('You are logged in as a admin.')
     expect(body).toContain('Create Consultation')
     expect(body).toContain('Join Consultation')
+    expect(body).toContain('View Logs')
     expect(body).toContain('href="/consultations/new"')
     expect(body).toContain('href="/join_consultation"')
+    expect(body).toContain('href="/logs"')
     expect(body).toContain('Find a Lecturer')
     expect(body).not.toContain('Scheduled Consultations')
   })

--- a/tests/unit/middleware/action_logger.test.js
+++ b/tests/unit/middleware/action_logger.test.js
@@ -171,18 +171,18 @@ describe('actionLogger middleware', () => {
   })
 
   describe('GET /institutions/universities', () => {
-    test('logs search term on success (302)', () => {
+    test('logs search term on success (200)', () => {
       const req = makeReq({ url: '/institutions/universities', query: { query: 'Wits' }, session: { user: { username: 'u', role: 'student' } } })
-      const res = makeRes(302)
+      const res = makeRes(200)
       runLogger(req, res)
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Searched Universities for Wits.'))
     })
 
-    test('logs not-found message on non-302/non-500', () => {
+    test('logs search term when response is 304 (browser cache hit)', () => {
       const req = makeReq({ url: '/institutions/universities', query: { query: 'Wits' }, session: { user: { username: 'u', role: 'student' } } })
-      const res = makeRes(200)
+      const res = makeRes(304)
       runLogger(req, res)
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('University not found in search results'))
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Searched Universities for Wits.'))
     })
 
     test('logs server error message on 500', () => {
@@ -194,18 +194,18 @@ describe('actionLogger middleware', () => {
   })
 
   describe('GET /institutions/faculties', () => {
-    test('logs search term on success (302)', () => {
+    test('logs search term on success (200)', () => {
       const req = makeReq({ url: '/institutions/faculties', query: { query: 'Engineering' }, session: { user: { username: 'u', role: 'student' } } })
-      const res = makeRes(302)
+      const res = makeRes(200)
       runLogger(req, res)
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Searched Faculties for Engineering.'))
     })
 
-    test('logs not-found message on non-302/non-500', () => {
+    test('logs search term when response is 304 (browser cache hit)', () => {
       const req = makeReq({ url: '/institutions/faculties', query: { query: 'Engineering' }, session: { user: { username: 'u', role: 'student' } } })
-      const res = makeRes(200)
+      const res = makeRes(304)
       runLogger(req, res)
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Faculty not found in search results'))
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Searched Faculties for Engineering.'))
     })
 
     test('logs server error message on 500', () => {
@@ -217,18 +217,18 @@ describe('actionLogger middleware', () => {
   })
 
   describe('GET /institutions/schools', () => {
-    test('logs search term on success (302)', () => {
+    test('logs search term on success (200)', () => {
       const req = makeReq({ url: '/institutions/schools', query: { query: 'EECE' }, session: { user: { username: 'u', role: 'student' } } })
-      const res = makeRes(302)
+      const res = makeRes(200)
       runLogger(req, res)
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Searched Schools for EECE.'))
     })
 
-    test('logs not-found message on non-302/non-500', () => {
+    test('logs search term when response is 304 (browser cache hit)', () => {
       const req = makeReq({ url: '/institutions/schools', query: { query: 'EECE' }, session: { user: { username: 'u', role: 'student' } } })
-      const res = makeRes(200)
+      const res = makeRes(304)
       runLogger(req, res)
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('School not found in search results'))
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Searched Schools for EECE.'))
     })
 
     test('logs server error message on 500', () => {

--- a/tests/unit/middleware/action_logger.test.js
+++ b/tests/unit/middleware/action_logger.test.js
@@ -1,5 +1,13 @@
 const actionLogger = require('../../../src/middleware/action_logger')
 
+jest.mock('../../../src/models/db', () => ({
+  connectToDatabase: jest.fn().mockResolvedValue(undefined)
+}))
+
+jest.mock('../../../src/models/logs_db', () => ({
+  addLog: jest.fn().mockResolvedValue({ acknowledged: true })
+}))
+
 const makeReq = function ({ method = 'GET', url = '/', session = {}, body = {}, query = {}, params = {} } = {}) {
   return { method, originalUrl: url, session, body, query, params }
 }
@@ -251,6 +259,15 @@ describe('actionLogger middleware', () => {
       const res = makeRes()
       runLogger(req, res)
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Viewed profile of drjones'))
+    })
+  })
+
+  describe('GET /logs', () => {
+    test('does not log the logs page', () => {
+      const req = makeReq({ url: '/logs', session: { user: { username: 'admin_user', role: 'admin' } } })
+      const res = makeRes()
+      runLogger(req, res)
+      expect(consoleSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/routes/home.test.js
+++ b/tests/unit/routes/home.test.js
@@ -212,11 +212,37 @@ describe('home route', () => {
     expect(body).toContain('Create Consultation')
     expect(body).toContain('/user_profile?user=morris')
     expect(body).toContain('href="/consultations/new"')
+    expect(body).not.toContain('View Logs')
     expect(body).toContain(currentMonthLabel)
     expect(body).toContain('calendar_table')
     expect(body).toContain('Sun')
     expect(body).toContain('Sat')
     expect(getLecturerAvailability).not.toHaveBeenCalled()
+  })
+
+  test('Renders the admin home page with the logs button', async () => {
+    const { loginResponse, sessionCookie } = await loginAs({
+      role: 'admin',
+      username: 'user'
+    })
+    const response = await fetch(`${baseUrl}/home`, {
+      headers: {
+        cookie: sessionCookie
+      }
+    })
+
+    const body = await response.text()
+
+    expect(loginResponse.status).toBe(302)
+    expect(loginResponse.headers.get('location')).toBe('/home')
+    expect(response.status).toBe(200)
+    expect(body).toContain('<title>Admin Home</title>')
+    expect(body).toContain('Hello user')
+    expect(body).toContain('You are logged in as a admin.')
+    expect(body).toContain('Create Consultation')
+    expect(body).toContain('Join Consultation')
+    expect(body).toContain('View Logs')
+    expect(body).toContain('href="/logs"')
   })
 
   test('Renders the lecturer home page after a successful login', async () => {
@@ -242,9 +268,27 @@ describe('home route', () => {
     expect(body).toContain('Choose an option below.')
     expect(body).toContain('User Profile')
     expect(body).toContain('/user_profile?user=lecturer1')
-    expect(body).not.toContain('Schedule a Consultation')
+    expect(body).not.toContain('View Logs')
     expect(body).toContain(currentMonthLabel)
     expect(body).toContain('calendar_table')
+  })
+
+  test('Denies non-admin users access to the logs page', async () => {
+    const { sessionCookie } = await loginAs({
+      role: 'student',
+      username: 'morris'
+    })
+
+    const response = await fetch(`${baseUrl}/logs`, {
+      headers: {
+        cookie: sessionCookie
+      }
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(403)
+    expect(body).toContain('Only the admin can view logs.')
   })
 
   test('Highlights lecturer availability on the home calendar', async () => {

--- a/tests/unit/routes/institution_search.test.js
+++ b/tests/unit/routes/institution_search.test.js
@@ -24,6 +24,10 @@ jest.mock('../../../src/models/university_db', () => ({
   searchUniversities: jest.fn()
 }))
 
+jest.mock('../../../src/models/logs_db', () => ({
+  addLog: jest.fn().mockResolvedValue(undefined)
+}))
+
 const http = require('node:http')
 
 const closeServer = async function (server) {
@@ -115,7 +119,7 @@ describe('institution search route', () => {
 
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({ results: [] })
-    expect(connectToDatabase).not.toHaveBeenCalled()
+    expect(connectToDatabase).toHaveBeenCalledTimes(0)
     expect(searchUniversities).not.toHaveBeenCalled()
   })
 
@@ -162,7 +166,7 @@ describe('institution search route', () => {
 
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({ results: [] })
-    expect(connectToDatabase).not.toHaveBeenCalled()
+    expect(connectToDatabase).toHaveBeenCalledTimes(0)
     expect(searchFaculties).not.toHaveBeenCalled()
   })
 
@@ -210,7 +214,7 @@ describe('institution search route', () => {
 
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({ results: [] })
-    expect(connectToDatabase).not.toHaveBeenCalled()
+    expect(connectToDatabase).toHaveBeenCalledTimes(0)
     expect(searchSchools).not.toHaveBeenCalled()
   })
 

--- a/tests/unit/routes/logs.test.js
+++ b/tests/unit/routes/logs.test.js
@@ -1,0 +1,203 @@
+jest.mock('../../../src/models/db', () => ({
+  closeDatabaseConnection: jest.fn(),
+  connectToDatabase: jest.fn().mockResolvedValue(undefined),
+  DATABASE_NAME: 'LetsTalk',
+  getCollection: jest.fn(),
+  getDb: jest.fn(),
+  getMongoUri: jest.fn()
+}))
+
+jest.mock('../../../src/models/logs_db', () => ({
+  addLog: jest.fn().mockResolvedValue(undefined),
+  getAllLogs: jest.fn()
+}))
+
+jest.mock('../../../src/models/user_db', () => ({
+  addUser: jest.fn(),
+  deleteUser: jest.fn(),
+  getUser: jest.fn()
+}))
+
+const http = require('node:http')
+const { connectToDatabase } = require('../../../src/models/db')
+const { getAllLogs } = require('../../../src/models/logs_db')
+const { getUser } = require('../../../src/models/user_db')
+const { hashPassword } = require('../../../src/utils/password')
+const app = require('../../../src/app')
+
+let baseUrl
+
+const MOCK_LOGS = [
+  { date: '2026-05-09', time: '13:00:00', username: 'user1', label: 'Logged in', httpCode: 302 },
+  { date: '2026-05-09', time: '12:55:00', username: 'user2', label: 'Viewed Home page', httpCode: 200 }
+]
+
+const closeServer = async function (server) {
+  if (!server) {
+    return
+  }
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+
+    if (typeof server.closeIdleConnections === 'function') {
+      server.closeIdleConnections()
+    }
+
+    if (typeof server.closeAllConnections === 'function') {
+      server.closeAllConnections()
+    }
+  })
+}
+
+const encodeForm = function (fields) {
+  return new URLSearchParams(fields).toString()
+}
+
+const loginAs = async function ({ role = 'admin', username = 'user' } = {}) {
+  getUser.mockResolvedValueOnce({
+    passwordHash: await hashPassword('testpass'),
+    role,
+    username
+  })
+
+  const loginResponse = await fetch(`${baseUrl}/login`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded'
+    },
+    body: encodeForm({
+      password: 'testpass',
+      username
+    }),
+    redirect: 'manual'
+  })
+
+  return {
+    loginResponse,
+    sessionCookie: loginResponse.headers.get('set-cookie')?.split(';')[0] || ''
+  }
+}
+
+describe('logs route', () => {
+  let server
+
+  beforeAll(async () => {
+    server = http.createServer(app)
+    await new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        baseUrl = `http://127.0.0.1:${server.address().port}`
+        resolve()
+      })
+    })
+  })
+
+  afterAll(async () => {
+    await closeServer(server)
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    connectToDatabase.mockResolvedValue(undefined)
+    getAllLogs.mockResolvedValue([])
+  })
+
+  test('Redirects unauthenticated users to login when requesting the logs page', async () => {
+    const response = await fetch(`${baseUrl}/logs`, {
+      redirect: 'manual'
+    })
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('/login')
+  })
+
+  test('Denies non-admin users access to the logs page', async () => {
+    const { sessionCookie } = await loginAs({
+      role: 'student',
+      username: 'student_user'
+    })
+
+    const response = await fetch(`${baseUrl}/logs`, {
+      headers: {
+        cookie: sessionCookie
+      }
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(403)
+    expect(body).toContain('Only the admin can view logs.')
+  })
+
+  test('Renders the logs page with logs for an admin user', async () => {
+    getAllLogs.mockResolvedValueOnce(MOCK_LOGS)
+
+    const { sessionCookie } = await loginAs({
+      role: 'admin',
+      username: 'user'
+    })
+
+    const response = await fetch(`${baseUrl}/logs`, {
+      headers: {
+        cookie: sessionCookie
+      }
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('<title>View Logs</title>')
+    expect(body).toContain('Hello user')
+    expect(body).toContain('[2026-05-09 13:00:00] user1 | Logged in | HTTP 302')
+    expect(body).toContain('[2026-05-09 12:55:00] user2 | Viewed Home page | HTTP 200')
+    expect(connectToDatabase).toHaveBeenCalled()
+    expect(getAllLogs).toHaveBeenCalled()
+  })
+
+  test('Renders the logs page with empty message when no logs exist', async () => {
+    getAllLogs.mockResolvedValueOnce([])
+
+    const { sessionCookie } = await loginAs({
+      role: 'admin',
+      username: 'user'
+    })
+
+    const response = await fetch(`${baseUrl}/logs`, {
+      headers: {
+        cookie: sessionCookie
+      }
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('No logs available.')
+  })
+
+  test('Returns a server error when loading logs fails', async () => {
+    getAllLogs.mockRejectedValueOnce(new Error('database unavailable'))
+
+    const { sessionCookie } = await loginAs({
+      role: 'admin',
+      username: 'user'
+    })
+
+    const response = await fetch(`${baseUrl}/logs`, {
+      headers: {
+        cookie: sessionCookie
+      }
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(500)
+    expect(body).toContain('Unable to load logs right now.')
+  })
+})

--- a/tests/unit/routes/logs.test.js
+++ b/tests/unit/routes/logs.test.js
@@ -9,7 +9,7 @@ jest.mock('../../../src/models/db', () => ({
 
 jest.mock('../../../src/models/logs_db', () => ({
   addLog: jest.fn().mockResolvedValue(undefined),
-  getAllLogs: jest.fn()
+  getLogsPage: jest.fn()
 }))
 
 jest.mock('../../../src/models/user_db', () => ({
@@ -20,7 +20,7 @@ jest.mock('../../../src/models/user_db', () => ({
 
 const http = require('node:http')
 const { connectToDatabase } = require('../../../src/models/db')
-const { getAllLogs } = require('../../../src/models/logs_db')
+const { getLogsPage } = require('../../../src/models/logs_db')
 const { getUser } = require('../../../src/models/user_db')
 const { hashPassword } = require('../../../src/utils/password')
 const app = require('../../../src/app')
@@ -106,7 +106,7 @@ describe('logs route', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     connectToDatabase.mockResolvedValue(undefined)
-    getAllLogs.mockResolvedValue([])
+    getLogsPage.mockResolvedValue({ logs: [], hasNextPage: false })
   })
 
   test('Redirects unauthenticated users to login when requesting the logs page', async () => {
@@ -137,7 +137,7 @@ describe('logs route', () => {
   })
 
   test('Renders the logs page with logs for an admin user', async () => {
-    getAllLogs.mockResolvedValueOnce(MOCK_LOGS)
+    getLogsPage.mockResolvedValueOnce({ logs: MOCK_LOGS, hasNextPage: false })
 
     const { sessionCookie } = await loginAs({
       role: 'admin',
@@ -158,11 +158,11 @@ describe('logs route', () => {
     expect(body).toContain('[2026-05-09 13:00:00] user1 | Logged in | HTTP 302')
     expect(body).toContain('[2026-05-09 12:55:00] user2 | Viewed Home page | HTTP 200')
     expect(connectToDatabase).toHaveBeenCalled()
-    expect(getAllLogs).toHaveBeenCalled()
+    expect(getLogsPage).toHaveBeenCalledWith(1, 50)
   })
 
   test('Renders the logs page with empty message when no logs exist', async () => {
-    getAllLogs.mockResolvedValueOnce([])
+    getLogsPage.mockResolvedValueOnce({ logs: [], hasNextPage: false })
 
     const { sessionCookie } = await loginAs({
       role: 'admin',
@@ -181,8 +181,49 @@ describe('logs route', () => {
     expect(body).toContain('No logs available.')
   })
 
+  test('Renders pagination links when additional pages are available', async () => {
+    getLogsPage.mockResolvedValueOnce({ logs: MOCK_LOGS, hasNextPage: true })
+
+    const { sessionCookie } = await loginAs({
+      role: 'admin',
+      username: 'user'
+    })
+
+    const response = await fetch(`${baseUrl}/logs?page=2`, {
+      headers: {
+        cookie: sessionCookie
+      }
+    })
+
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('href="/logs?page=1"')
+    expect(body).toContain('href="/logs?page=3"')
+    expect(body).toContain('Page 2')
+    expect(getLogsPage).toHaveBeenCalledWith(2, 50)
+  })
+
+  test('Defaults to page 1 for invalid page query values', async () => {
+    getLogsPage.mockResolvedValueOnce({ logs: MOCK_LOGS, hasNextPage: false })
+
+    const { sessionCookie } = await loginAs({
+      role: 'admin',
+      username: 'user'
+    })
+
+    const response = await fetch(`${baseUrl}/logs?page=banana`, {
+      headers: {
+        cookie: sessionCookie
+      }
+    })
+
+    expect(response.status).toBe(200)
+    expect(getLogsPage).toHaveBeenCalledWith(1, 50)
+  })
+
   test('Returns a server error when loading logs fails', async () => {
-    getAllLogs.mockRejectedValueOnce(new Error('database unavailable'))
+    getLogsPage.mockRejectedValueOnce(new Error('database unavailable'))
 
     const { sessionCookie } = await loginAs({
       role: 'admin',


### PR DESCRIPTION
closes #54 and closes #50

Add admin user type (has full access to student functions + exclusive admin view logs button on home page)
change seeded user to admin type
save logs to db (saving, time, date, username, label and returned http code)
significant refactor to tests to account for logging
all saving to databases during tests now disabled (good practice but strictly necessary for Logs collection addition)
add logs page with pagination to limit displayed logs to 50 most recent

nb: all future additons to logs still only requires edits to src/middleware/actions_logger.js. Dont worry about src/models/Logs.js