### PR TITLE
Student cancel

### DIFF
--- a/src/models/consultation_db.js
+++ b/src/models/consultation_db.js
@@ -253,6 +253,81 @@ const getConsultationsForCalendar = async function (username, monthStart, monthE
   }).filter(Boolean)
 }
 
+const CANCEL_RESULT_REASONS = {
+  NOT_FOUND: 'not-found',
+  NOT_ORGANISER: 'not-organiser',
+  PAST_CONSULTATION: 'past-consultation'
+}
+
+/**
+ * Returns upcoming consultations for a student, with an isOrganiser flag for each.
+ * @param {string} username - Student username.
+ * @returns {Promise<Array<object>>} Upcoming consultations sorted by datetime ascending.
+ */
+const getConsultationsForStudent = async function (username) {
+  const consultations = await consultationsCollection().find({ attendees: username }).toArray()
+  if (consultations.length === 0) return []
+
+  const now = new Date()
+  const upcoming = consultations.filter(function (c) {
+    return c._id && new Date(c.datetime) > now
+  })
+
+  if (upcoming.length === 0) return []
+
+  const lecturerIds = [...new Set(upcoming.map(function (c) { return c.lecturerId }).filter(Boolean))]
+  const [users, availabilities] = await Promise.all([
+    usersCollection().find({ username: { $in: lecturerIds } }).toArray(),
+    getCollection(AVAILABILITY_COLLECTION_NAME).find({ username: { $in: lecturerIds } }).toArray()
+  ])
+
+  const usersByUsername = new Map(users.map(function (u) { return [u.username, u] }))
+  const availabilitiesByUsername = new Map(availabilities.map(function (a) { return [a.username, a] }))
+
+  return upcoming.sort(function (a, b) {
+    return (a.datetime || '').localeCompare(b.datetime || '')
+  }).map(function (consultation) {
+    return {
+      date: consultation.datetime?.slice(0, 10) || '',
+      id: consultation._id.toString(),
+      isOrganiser: consultation.organiserId === username,
+      lecturer: buildDisplayName(usersByUsername.get(consultation.lecturerId), consultation.lecturerId),
+      name: consultation.title || 'Untitled consultation',
+      time: buildConsultationTime(consultation.datetime, availabilitiesByUsername.get(consultation.lecturerId)?.duration)
+    }
+  })
+}
+
+/**
+ * Deletes a future consultation if the requesting user is its organiser.
+ * @param {string} consultationId - Consultation id string.
+ * @param {string} organiserId - Username of the requester.
+ * @returns {Promise<{success: boolean, statusCode?: number, reason?: string}>} Cancel result.
+ */
+const cancelConsultation = async function (consultationId, organiserId) {
+  if (!ObjectId.isValid(consultationId)) {
+    return { success: false, statusCode: 404, reason: CANCEL_RESULT_REASONS.NOT_FOUND }
+  }
+
+  const objectId = new ObjectId(consultationId)
+  const consultation = await consultationsCollection().findOne({ _id: objectId })
+
+  if (!consultation) {
+    return { success: false, statusCode: 404, reason: CANCEL_RESULT_REASONS.NOT_FOUND }
+  }
+
+  if (consultation.organiserId !== organiserId) {
+    return { success: false, statusCode: 403, reason: CANCEL_RESULT_REASONS.NOT_ORGANISER }
+  }
+
+  if (new Date(consultation.datetime) <= new Date()) {
+    return { success: false, statusCode: 400, reason: CANCEL_RESULT_REASONS.PAST_CONSULTATION }
+  }
+
+  await consultationsCollection().deleteOne({ _id: objectId })
+  return { success: true }
+}
+
 /**
  * Adds a student attendee to an existing consultation when space remains.
  * @param {string} consultationId - Consultation id string.
@@ -291,7 +366,10 @@ const addStudentToConsultation = async function (consultationId, username) {
 module.exports = {
   addConsultation,
   addStudentToConsultation,
+  cancelConsultation,
+  CANCEL_RESULT_REASONS,
   getConsultationsForCalendar,
+  getConsultationsForStudent,
   getUpcomingConsultationsForLecturer,
   JOIN_RESULT_REASONS,
   listConsultationsForLecturerOnDate,

--- a/src/public/scripts/manage_consultations.js
+++ b/src/public/scripts/manage_consultations.js
@@ -1,0 +1,121 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const btn = document.getElementById('manage_consultations_btn')
+  const dialog = document.getElementById('manage_consultations_dialog')
+  const closeBtn = document.getElementById('close_manage_dialog')
+  const list = document.getElementById('manage_consultations_list')
+  const msg = document.getElementById('manage_consultations_msg')
+
+  if (!btn || !dialog || !closeBtn || !list || !msg) {
+    return
+  }
+
+  const showMsg = function (text, isError) {
+    msg.textContent = text
+    msg.className = isError ? 'error' : 'success'
+  }
+
+  const hideMsg = function () {
+    msg.textContent = ''
+    msg.className = 'is_hidden'
+  }
+
+  const buildConsultationCard = function (consultation) {
+    const article = document.createElement('article')
+    article.className = 'dashboard_consultation_card'
+    article.dataset.consultationId = consultation.id
+
+    const title = document.createElement('h3')
+    title.textContent = consultation.name
+    article.appendChild(title)
+
+    const lecturer = document.createElement('p')
+    lecturer.className = 'dashboard_consultation_meta'
+    lecturer.textContent = `Lecturer: ${consultation.lecturer}`
+    article.appendChild(lecturer)
+
+    const dateTime = document.createElement('p')
+    dateTime.className = 'dashboard_consultation_meta'
+    dateTime.textContent = `Date: ${consultation.date} · Time: ${consultation.time}`
+    article.appendChild(dateTime)
+
+    if (consultation.isOrganiser) {
+      const cancelBtn = document.createElement('button')
+      cancelBtn.type = 'button'
+      cancelBtn.className = 'back_link'
+      cancelBtn.style.marginTop = '12px'
+      cancelBtn.textContent = 'Cancel Consultation'
+      cancelBtn.dataset.cancelId = consultation.id
+      article.appendChild(cancelBtn)
+    }
+
+    return article
+  }
+
+  const loadConsultations = async function () {
+    list.innerHTML = '<p>Loading…</p>'
+    hideMsg()
+
+    try {
+      const response = await fetch('/consultations')
+      const data = await response.json()
+
+      if (!response.ok || !Array.isArray(data.consultations)) {
+        list.innerHTML = '<p>Unable to load consultations right now.</p>'
+        return
+      }
+
+      if (data.consultations.length === 0) {
+        list.innerHTML = '<p>You have no upcoming consultations.</p>'
+        return
+      }
+
+      list.innerHTML = ''
+      data.consultations.forEach(function (consultation) {
+        list.appendChild(buildConsultationCard(consultation))
+      })
+    } catch {
+      list.innerHTML = '<p>Unable to load consultations right now.</p>'
+    }
+  }
+
+  const handleCancel = async function (consultationId) {
+    if (!window.confirm('Are you sure you want to cancel this consultation? This cannot be undone.')) {
+      return
+    }
+
+    try {
+      const response = await fetch(`/consultations/${consultationId}`, { method: 'DELETE' })
+      const data = await response.json()
+
+      if (response.ok && data.success) {
+        showMsg('Consultation cancelled successfully.', false)
+        setTimeout(function () { window.location.reload() }, 1000)
+      } else {
+        showMsg(data.error || 'Unable to cancel consultation.', true)
+      }
+    } catch {
+      showMsg('Unable to cancel consultation right now.', true)
+    }
+  }
+
+  list.addEventListener('click', function (event) {
+    const cancelBtn = event.target.closest('[data-cancel-id]')
+    if (!cancelBtn) return
+    handleCancel(cancelBtn.dataset.cancelId)
+  })
+
+  btn.addEventListener('click', function () {
+    loadConsultations()
+    dialog.showModal()
+  })
+
+  closeBtn.addEventListener('click', function () {
+    dialog.close()
+  })
+
+  dialog.addEventListener('click', function (event) {
+    if (event.target === dialog) {
+      dialog.close()
+    }
+  })
+})

--- a/src/public/scripts/manage_consultations.js
+++ b/src/public/scripts/manage_consultations.js
@@ -19,6 +19,11 @@ document.addEventListener('DOMContentLoaded', function () {
     msg.className = 'is_hidden'
   }
 
+  /**
+   * Builds a card element for a single consultation.
+   * @param {object} consultation - Enriched consultation object from GET /consultations.
+   * @returns {HTMLElement} Article element ready to insert into the list.
+   */
   const buildConsultationCard = function (consultation) {
     const article = document.createElement('article')
     article.className = 'dashboard_consultation_card'
@@ -51,6 +56,9 @@ document.addEventListener('DOMContentLoaded', function () {
     return article
   }
 
+  /**
+   * Fetches the student's upcoming consultations and renders them into the modal list.
+   */
   const loadConsultations = async function () {
     list.innerHTML = '<p>Loading…</p>'
     hideMsg()
@@ -78,6 +86,11 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
+  /**
+   * Prompts the user for confirmation then sends a DELETE request for the consultation.
+   * Reloads the page on success so the calendar reflects the removed slot.
+   * @param {string} consultationId - The id of the consultation to cancel.
+   */
   const handleCancel = async function (consultationId) {
     if (!window.confirm('Are you sure you want to cancel this consultation? This cannot be undone.')) {
       return
@@ -89,6 +102,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
       if (response.ok && data.success) {
         showMsg('Consultation cancelled successfully.', false)
+        // Delay gives the user time to read the success message before the page refreshes
         setTimeout(function () { window.location.reload() }, 1000)
       } else {
         showMsg(data.error || 'Unable to cancel consultation.', true)

--- a/src/public/scripts/manage_consultations.js
+++ b/src/public/scripts/manage_consultations.js
@@ -46,7 +46,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (consultation.isOrganiser) {
       const cancelBtn = document.createElement('button')
       cancelBtn.type = 'button'
-      cancelBtn.className = 'back_link'
+      cancelBtn.className = 'btn_danger'
       cancelBtn.style.marginTop = '12px'
       cancelBtn.textContent = 'Cancel Consultation'
       cancelBtn.dataset.cancelId = consultation.id

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -399,6 +399,35 @@ a {
   display: none;
 }
 
+.manage_dialog {
+  width: min(90vw, 600px);
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 28px;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-card);
+}
+
+.manage_dialog::backdrop {
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.manage_dialog_header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.manage_dialog_title {
+  margin: 0;
+}
+
+.manage_dialog_close {
+  background: var(--color-secondary);
+}
+
 @media (max-width: 700px) {
   .home_navigation_actions {
     grid-template-columns: 1fr;

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -428,6 +428,10 @@ a {
   background: var(--color-secondary);
 }
 
+.btn_danger {
+  background: var(--color-error-text);
+}
+
 @media (max-width: 700px) {
   .home_navigation_actions {
     grid-template-columns: 1fr;

--- a/src/routes/consultations.js
+++ b/src/routes/consultations.js
@@ -1,12 +1,17 @@
 const express = require('express')
 const { connectToDatabase } = require('../models/db')
-const { addConsultation, listConsultationsForLecturerOnDate } = require('../models/consultation_db')
+const { addConsultation, cancelConsultation, getConsultationsForStudent, listConsultationsForLecturerOnDate } = require('../models/consultation_db')
 const { getLecturerAvailability } = require('../models/lecturer_availability_db')
 const { addMinutesToTime, validateLecturerAvailability, findOverlappingConsultation } = require('../services/consultation_availability_validation')
 const { getUser, searchLecturers } = require('../models/user_db')
 
 const router = express.Router()
 const DATETIME_LOCAL_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/
+const CANCEL_ERROR_MESSAGES = {
+  'not-found': 'Consultation not found.',
+  'not-organiser': 'Only the organiser can cancel this consultation.',
+  'past-consultation': 'Past consultations cannot be cancelled.'
+}
 
 /**
  * Converts lecturer documents into option objects for the consultation form.
@@ -283,6 +288,44 @@ router.post('/', async function (req, res) {
       universityId,
       username: organiserId
     })
+  }
+})
+
+router.get('/', async function (req, res) {
+  const { username = '', role = '' } = req.session?.user || {}
+
+  if (role !== 'student' && role !== 'admin') {
+    return res.status(403).json({ error: 'Only students can view their consultations.' })
+  }
+
+  try {
+    await connectToDatabase()
+    const consultations = await getConsultationsForStudent(username)
+    return res.json({ consultations })
+  } catch {
+    return res.status(500).json({ error: 'Unable to load consultations right now.' })
+  }
+})
+
+router.delete('/:id', async function (req, res) {
+  const { username = '', role = '' } = req.session?.user || {}
+
+  if (role !== 'student' && role !== 'admin') {
+    return res.status(403).json({ error: 'Only students can cancel consultations.' })
+  }
+
+  try {
+    await connectToDatabase()
+    const result = await cancelConsultation(req.params.id, username)
+
+    return result.success
+      ? res.json({ success: true })
+      : res.status(result.statusCode || 400).json({
+        success: false,
+        error: CANCEL_ERROR_MESSAGES[result.reason] || 'Unable to cancel consultation.'
+      })
+  } catch {
+    return res.status(500).json({ success: false, error: 'Unable to cancel consultation right now.' })
   }
 })
 

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -6,6 +6,7 @@
   <title><%= title %></title>
   <link rel="stylesheet" href="/styles/main.css">
   <script src="/scripts/lecturer_search.js" defer></script>
+  <script src="/scripts/manage_consultations.js" defer></script>
 </head>
 <body class="page page_home">
   <main class="card card_even_wider text_center">
@@ -27,11 +28,21 @@
           <a class="home_navigation_primary" href="/user_profile?user=<%= encodeURIComponent(username) %>">User Profile</a>
           <a href="/consultations/new">Create Consultation</a>
           <a href="/join_consultation">Join Consultation</a>
+          <button type="button" id="manage_consultations_btn" class="home_navigation_primary">Manage Consultations</button>
         </div>
         <% if (role === 'admin') { %>
           <a href="/logs" style="width: fit-content; margin: 4px auto 0; padding: 8px 14px; background: var(--color-secondary); font-size: 0.92rem;">View Logs</a>
         <% } %>
       </section>
+
+      <dialog id="manage_consultations_dialog" class="manage_dialog">
+        <div class="manage_dialog_header">
+          <h2 class="manage_dialog_title">My Consultations</h2>
+          <button type="button" id="close_manage_dialog" class="manage_dialog_close">Close</button>
+        </div>
+        <p id="manage_consultations_msg" class="is_hidden" aria-live="polite"></p>
+        <div id="manage_consultations_list"></div>
+      </dialog>
     <% } else if (role === 'lecturer' && username) { %>
       <section class="home_navigation">
         <h2 class="home_navigation_title">Navigation</h2>

--- a/tests/E2E/cancel_consultation.js
+++ b/tests/E2E/cancel_consultation.js
@@ -1,0 +1,118 @@
+const path = require('node:path')
+const { test, expect } = require('@playwright/test')
+const { connectToDatabase, closeDatabaseConnection, getCollection } = require('../../src/models/db')
+require('dotenv').config({ path: path.resolve(__dirname, '../../.env'), quiet: true })
+
+const SEEDED_STUDENT_USERNAME = 'user'
+const SEEDED_LECTURER_USERNAME = 'user1'
+const PASSWORD = 'password'
+const TEST_ID = `${process.pid}${Date.now()}`
+const TEST_STUDENT_USERNAME = `e2estud${TEST_ID}cancel`
+const TEST_LECTURER_USERNAME = `e2elect${TEST_ID}cancel`
+
+test.describe('cancel consultation E2E', () => {
+  test.skip(!process.env.MONGODB_URI, 'Requires a writable MongoDB test database.')
+
+  const futureDatetime = function () {
+    const date = new Date()
+    date.setDate(date.getDate() + 7)
+    date.setHours(9, 0, 0, 0)
+    const pad = (n) => String(n).padStart(2, '0')
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T09:00`
+  }
+
+  const loginAsStudent = async function (page) {
+    await page.goto('/login')
+    await page.getByRole('textbox', { name: 'Username' }).fill(TEST_STUDENT_USERNAME)
+    await page.getByLabel('Password').fill(PASSWORD)
+    await page.getByRole('button', { name: 'Log In' }).click()
+    await expect(page).toHaveURL(/\/home$/)
+  }
+
+  test.beforeAll(async function () {
+    await connectToDatabase()
+    const users = await getCollection('User')
+    const seededStudent = await users.findOne({ username: SEEDED_STUDENT_USERNAME })
+    const seededLecturer = await users.findOne({ username: SEEDED_LECTURER_USERNAME })
+
+    if (!seededStudent || !seededLecturer) {
+      throw new Error('Seeded users for cancel consultation E2E tests were not found.')
+    }
+
+    const { _id: _sid, username: _su, email: _se, ...studentFields } = seededStudent
+    const { _id: _lid, username: _lu, email: _le, ...lecturerFields } = seededLecturer
+
+    await users.deleteMany({ username: { $in: [TEST_STUDENT_USERNAME, TEST_LECTURER_USERNAME] } })
+    await users.insertMany([
+      { ...studentFields, email: `${TEST_STUDENT_USERNAME}@example.test`, username: TEST_STUDENT_USERNAME },
+      { ...lecturerFields, email: `${TEST_LECTURER_USERNAME}@example.test`, username: TEST_LECTURER_USERNAME }
+    ])
+  })
+
+  test.afterEach(async function () {
+    await connectToDatabase()
+    await getCollection('Consultation').deleteMany({ organiserId: TEST_STUDENT_USERNAME })
+  })
+
+  test.afterAll(async function () {
+    await connectToDatabase()
+    await getCollection('Consultation').deleteMany({ organiserId: TEST_STUDENT_USERNAME })
+    await getCollection('User').deleteMany({ username: { $in: [TEST_STUDENT_USERNAME, TEST_LECTURER_USERNAME] } })
+    await closeDatabaseConnection()
+  })
+
+  test('Manage Consultations button is visible on the student home page', async ({ page }) => {
+    await loginAsStudent(page)
+
+    await expect(page.getByRole('button', { name: 'Manage Consultations' })).toBeVisible()
+  })
+
+  test('modal shows the consultation with a Cancel button for consultations the student organised', async ({ page }) => {
+    await connectToDatabase()
+    await getCollection('Consultation').insertOne({
+      attendees: [TEST_STUDENT_USERNAME],
+      capacity: 1,
+      datetime: futureDatetime(),
+      lecturerId: TEST_LECTURER_USERNAME,
+      organiserId: TEST_STUDENT_USERNAME,
+      title: 'E2E Cancel Modal Test'
+    })
+
+    await loginAsStudent(page)
+    await page.getByRole('button', { name: 'Manage Consultations' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toContainText('E2E Cancel Modal Test')
+    await expect(dialog.getByRole('button', { name: 'Cancel Consultation' })).toBeVisible()
+  })
+
+  test('confirming the cancel prompt removes the consultation from the database', async ({ page }) => {
+    await connectToDatabase()
+    const { insertedId } = await getCollection('Consultation').insertOne({
+      attendees: [TEST_STUDENT_USERNAME],
+      capacity: 1,
+      datetime: futureDatetime(),
+      lecturerId: TEST_LECTURER_USERNAME,
+      organiserId: TEST_STUDENT_USERNAME,
+      title: 'E2E Consultation To Cancel'
+    })
+
+    await loginAsStudent(page)
+    await page.getByRole('button', { name: 'Manage Consultations' }).click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+
+    page.once('dialog', async function (nativeDialog) {
+      await nativeDialog.accept()
+    })
+
+    await Promise.all([
+      page.waitForNavigation(),
+      page.getByRole('button', { name: 'Cancel Consultation' }).click()
+    ])
+
+    await connectToDatabase()
+    const remaining = await getCollection('Consultation').findOne({ _id: insertedId })
+    expect(remaining).toBeNull()
+  })
+})

--- a/tests/integration/cancel_consultation.test.js
+++ b/tests/integration/cancel_consultation.test.js
@@ -1,0 +1,168 @@
+const http = require('node:http')
+const { closeDatabaseConnection, connectToDatabase, getCollection } = require('../../src/models/db')
+const app = require('../../src/app')
+
+const PASSWORD = 'password'
+const SEEDED_STUDENT_USERNAME = 'user'
+const SEEDED_LECTURER_USERNAME = 'user1'
+const TEST_ID = `${process.pid}${Date.now()}`
+const TEST_STUDENT_USERNAME = `iteststud${TEST_ID}cancel`
+const TEST_LECTURER_USERNAME = `itestlect${TEST_ID}cancel`
+const TEST_UNIVERSITY_ID = `integration-cancel-university-${TEST_ID}`
+const RUN_DB_TEST = process.env.MONGODB_URI ? test : test.skip
+
+const closeServer = async function (server) {
+  if (!server) {
+    return
+  }
+
+  await new Promise(function (resolve, reject) {
+    server.close(function (error) {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+
+    if (typeof server.closeIdleConnections === 'function') {
+      server.closeIdleConnections()
+    }
+
+    if (typeof server.closeAllConnections === 'function') {
+      server.closeAllConnections()
+    }
+  })
+}
+
+const encodeForm = function (fields) {
+  return new URLSearchParams(fields).toString()
+}
+
+const loginAs = async function (baseUrl, { password, username }) {
+  const response = await fetch(`${baseUrl}/login`, {
+    body: encodeForm({ password, username }),
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    method: 'POST',
+    redirect: 'manual'
+  })
+
+  return response.headers.get('set-cookie')?.split(';')[0] || ''
+}
+
+const futureDatetime = function () {
+  const date = new Date()
+  date.setDate(date.getDate() + 7)
+  date.setHours(9, 0, 0, 0)
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T09:00`
+}
+
+describe('cancel consultation integration flow', () => {
+  let baseUrl
+  let server
+
+  beforeAll(async function () {
+    if (!process.env.MONGODB_URI) {
+      return
+    }
+
+    await connectToDatabase()
+    const users = await getCollection('User')
+    const seededStudent = await users.findOne({ username: SEEDED_STUDENT_USERNAME })
+    const seededLecturer = await users.findOne({ username: SEEDED_LECTURER_USERNAME })
+
+    if (!seededStudent || !seededLecturer) {
+      throw new Error('Seeded users for cancel consultation integration tests were not found.')
+    }
+
+    const { _id: _sid, username: _su, email: _se, ...studentFields } = seededStudent
+    const { _id: _lid, username: _lu, email: _le, ...lecturerFields } = seededLecturer
+
+    await users.deleteMany({ username: { $in: [TEST_STUDENT_USERNAME, TEST_LECTURER_USERNAME] } })
+    await users.insertMany([
+      { ...studentFields, email: `${TEST_STUDENT_USERNAME}@example.test`, universityId: TEST_UNIVERSITY_ID, username: TEST_STUDENT_USERNAME },
+      { ...lecturerFields, email: `${TEST_LECTURER_USERNAME}@example.test`, universityId: TEST_UNIVERSITY_ID, username: TEST_LECTURER_USERNAME }
+    ])
+
+    server = http.createServer(app)
+
+    await new Promise(function (resolve) {
+      server.listen(0, '127.0.0.1', function () {
+        baseUrl = `http://127.0.0.1:${server.address().port}`
+        resolve()
+      })
+    })
+  })
+
+  afterEach(async function () {
+    if (!process.env.MONGODB_URI) {
+      return
+    }
+
+    await connectToDatabase()
+    await getCollection('Consultation').deleteMany({ organiserId: TEST_STUDENT_USERNAME })
+  })
+
+  afterAll(async function () {
+    if (!process.env.MONGODB_URI) {
+      return
+    }
+
+    await connectToDatabase()
+    await getCollection('Consultation').deleteMany({ organiserId: TEST_STUDENT_USERNAME })
+    await getCollection('User').deleteMany({ username: { $in: [TEST_STUDENT_USERNAME, TEST_LECTURER_USERNAME] } })
+
+    await closeServer(server)
+    await closeDatabaseConnection()
+  })
+
+  RUN_DB_TEST('returns the students upcoming consultations', async function () {
+    await connectToDatabase()
+    const { insertedId } = await getCollection('Consultation').insertOne({
+      attendees: [TEST_STUDENT_USERNAME],
+      capacity: 1,
+      datetime: futureDatetime(),
+      lecturerId: TEST_LECTURER_USERNAME,
+      organiserId: TEST_STUDENT_USERNAME,
+      title: 'Integration cancel test consultation'
+    })
+
+    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: TEST_STUDENT_USERNAME })
+    const response = await fetch(`${baseUrl}/consultations`, {
+      headers: { cookie: sessionCookie }
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(Array.isArray(data.consultations)).toBe(true)
+    expect(data.consultations.some(function (c) { return c.id === insertedId.toString() })).toBe(true)
+  })
+
+  RUN_DB_TEST('deletes the consultation and returns success when the organiser cancels', async function () {
+    await connectToDatabase()
+    const { insertedId } = await getCollection('Consultation').insertOne({
+      attendees: [TEST_STUDENT_USERNAME],
+      capacity: 1,
+      datetime: futureDatetime(),
+      lecturerId: TEST_LECTURER_USERNAME,
+      organiserId: TEST_STUDENT_USERNAME,
+      title: 'Consultation to be cancelled'
+    })
+
+    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: TEST_STUDENT_USERNAME })
+    const response = await fetch(`${baseUrl}/consultations/${insertedId.toString()}`, {
+      headers: { cookie: sessionCookie },
+      method: 'DELETE'
+    })
+    const data = await response.json()
+
+    await connectToDatabase()
+    const remaining = await getCollection('Consultation').findOne({ _id: insertedId })
+
+    expect(response.status).toBe(200)
+    expect(data.success).toBe(true)
+    expect(remaining).toBeNull()
+  })
+})

--- a/tests/unit/models/consultation_db.test.js
+++ b/tests/unit/models/consultation_db.test.js
@@ -7,7 +7,10 @@ const { getCollection } = require('../../../src/models/db')
 const {
   addConsultation,
   addStudentToConsultation,
+  cancelConsultation,
+  CANCEL_RESULT_REASONS,
   getConsultationsForCalendar,
+  getConsultationsForStudent,
   getUpcomingConsultationsForLecturer,
   JOIN_RESULT_REASONS,
   listConsultationsForLecturerOnDate,
@@ -22,6 +25,7 @@ describe('consultation database operations', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockConsultationCollection = {
+      deleteOne: jest.fn(),
       find: jest.fn(),
       findOne: jest.fn(),
       insertOne: jest.fn(),
@@ -358,6 +362,160 @@ describe('consultation database operations', () => {
       const result = await getConsultationsForCalendar('student1', MONTH_START, MONTH_END)
 
       expect(result[0].time).toBe('10:00 to 11:00')
+    })
+  })
+
+  describe('getConsultationsForStudent', () => {
+    test('returns an empty array when the student has no consultations', async () => {
+      mockConsultationCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) })
+
+      const result = await getConsultationsForStudent('student1')
+
+      expect(result).toEqual([])
+    })
+
+    test('returns only future consultations', async () => {
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+      const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+      const futureId = new ObjectId()
+
+      mockConsultationCollection.find.mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([
+          { _id: futureId, attendees: ['student1'], datetime: futureDate, lecturerId: 'lecturer1', organiserId: 'student1', title: 'Future' },
+          { _id: new ObjectId(), attendees: ['student1'], datetime: pastDate, lecturerId: 'lecturer1', organiserId: 'student1', title: 'Past' }
+        ])
+      })
+      mockUserCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) })
+      mockLecturerAvailabilityCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) })
+
+      const result = await getConsultationsForStudent('student1')
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe(futureId.toString())
+    })
+
+    test('sets isOrganiser to true when the student is the organiser', async () => {
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+
+      mockConsultationCollection.find.mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([
+          { _id: new ObjectId(), attendees: ['student1'], datetime: futureDate, lecturerId: 'lecturer1', organiserId: 'student1', title: 'My consultation' }
+        ])
+      })
+      mockUserCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) })
+      mockLecturerAvailabilityCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) })
+
+      const result = await getConsultationsForStudent('student1')
+
+      expect(result[0].isOrganiser).toBe(true)
+    })
+
+    test('sets isOrganiser to false when the student joined but did not organise', async () => {
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+
+      mockConsultationCollection.find.mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([
+          { _id: new ObjectId(), attendees: ['student1'], datetime: futureDate, lecturerId: 'lecturer1', organiserId: 'student2', title: 'Someone elses consultation' }
+        ])
+      })
+      mockUserCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) })
+      mockLecturerAvailabilityCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) })
+
+      const result = await getConsultationsForStudent('student1')
+
+      expect(result[0].isOrganiser).toBe(false)
+    })
+
+    test('builds the lecturer display name from the user document', async () => {
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+
+      mockConsultationCollection.find.mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([
+          { _id: new ObjectId(), attendees: ['student1'], datetime: futureDate, lecturerId: 'lecturer1', organiserId: 'student1', title: 'DS Review' }
+        ])
+      })
+      mockUserCollection.find.mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([{ username: 'lecturer1', firstName: 'Jane', lastName: 'Doe' }])
+      })
+      mockLecturerAvailabilityCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) })
+
+      const result = await getConsultationsForStudent('student1')
+
+      expect(result[0].lecturer).toBe('Jane Doe')
+    })
+
+    test('returns consultations sorted by datetime ascending', async () => {
+      const firstDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+      const secondDate = new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString().slice(0, 16)
+      const firstId = new ObjectId()
+      const secondId = new ObjectId()
+
+      mockConsultationCollection.find.mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([
+          { _id: secondId, attendees: ['student1'], datetime: secondDate, lecturerId: 'lecturer1', organiserId: 'student1', title: 'Later' },
+          { _id: firstId, attendees: ['student1'], datetime: firstDate, lecturerId: 'lecturer1', organiserId: 'student1', title: 'Earlier' }
+        ])
+      })
+      mockUserCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) })
+      mockLecturerAvailabilityCollection.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) })
+
+      const result = await getConsultationsForStudent('student1')
+
+      expect(result[0].id).toBe(firstId.toString())
+      expect(result[1].id).toBe(secondId.toString())
+    })
+  })
+
+  describe('cancelConsultation', () => {
+    test('returns not-found for an invalid ObjectId', async () => {
+      const result = await cancelConsultation('not-a-valid-id', 'student1')
+
+      expect(result).toEqual({ success: false, statusCode: 404, reason: CANCEL_RESULT_REASONS.NOT_FOUND })
+      expect(mockConsultationCollection.findOne).not.toHaveBeenCalled()
+    })
+
+    test('returns not-found when the consultation does not exist', async () => {
+      const id = new ObjectId()
+      mockConsultationCollection.findOne.mockResolvedValue(null)
+
+      const result = await cancelConsultation(id.toString(), 'student1')
+
+      expect(result).toEqual({ success: false, statusCode: 404, reason: CANCEL_RESULT_REASONS.NOT_FOUND })
+      expect(mockConsultationCollection.deleteOne).not.toHaveBeenCalled()
+    })
+
+    test('returns not-organiser when the requester did not create the consultation', async () => {
+      const id = new ObjectId()
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+      mockConsultationCollection.findOne.mockResolvedValue({ _id: id, datetime: futureDate, organiserId: 'student2' })
+
+      const result = await cancelConsultation(id.toString(), 'student1')
+
+      expect(result).toEqual({ success: false, statusCode: 403, reason: CANCEL_RESULT_REASONS.NOT_ORGANISER })
+      expect(mockConsultationCollection.deleteOne).not.toHaveBeenCalled()
+    })
+
+    test('returns past-consultation when the consultation datetime has already passed', async () => {
+      const id = new ObjectId()
+      const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+      mockConsultationCollection.findOne.mockResolvedValue({ _id: id, datetime: pastDate, organiserId: 'student1' })
+
+      const result = await cancelConsultation(id.toString(), 'student1')
+
+      expect(result).toEqual({ success: false, statusCode: 400, reason: CANCEL_RESULT_REASONS.PAST_CONSULTATION })
+      expect(mockConsultationCollection.deleteOne).not.toHaveBeenCalled()
+    })
+
+    test('deletes the consultation and returns success when all checks pass', async () => {
+      const id = new ObjectId()
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+      mockConsultationCollection.findOne.mockResolvedValue({ _id: id, datetime: futureDate, organiserId: 'student1' })
+      mockConsultationCollection.deleteOne.mockResolvedValue({ deletedCount: 1 })
+
+      const result = await cancelConsultation(id.toString(), 'student1')
+
+      expect(mockConsultationCollection.deleteOne).toHaveBeenCalledWith({ _id: id })
+      expect(result).toEqual({ success: true })
     })
   })
 

--- a/tests/unit/routes/consultations.test.js
+++ b/tests/unit/routes/consultations.test.js
@@ -1,5 +1,7 @@
 jest.mock('../../../src/models/consultation_db', () => ({
   addConsultation: jest.fn(),
+  cancelConsultation: jest.fn(),
+  getConsultationsForStudent: jest.fn(),
   listConsultationsForLecturerOnDate: jest.fn()
 }))
 
@@ -20,7 +22,7 @@ const http = require('node:http')
 const path = require('node:path')
 const express = require('express')
 
-const { addConsultation, listConsultationsForLecturerOnDate } = require('../../../src/models/consultation_db')
+const { addConsultation, cancelConsultation, getConsultationsForStudent, listConsultationsForLecturerOnDate } = require('../../../src/models/consultation_db')
 const { connectToDatabase } = require('../../../src/models/db')
 const { getLecturerAvailability } = require('../../../src/models/lecturer_availability_db')
 const { getUser, searchLecturers } = require('../../../src/models/user_db')
@@ -110,6 +112,8 @@ describe('consultations route', () => {
       username: 'morris'
     }
     addConsultation.mockResolvedValue({ acknowledged: true, insertedId: 'consultation-id' })
+    cancelConsultation.mockResolvedValue({ success: true })
+    getConsultationsForStudent.mockResolvedValue([])
     listConsultationsForLecturerOnDate.mockResolvedValue([])
     connectToDatabase.mockResolvedValue(undefined)
     getLecturerAvailability.mockResolvedValue({
@@ -268,6 +272,109 @@ describe('consultations route', () => {
     expect(response.status).toBe(400)
     expect(body).toContain('Please select a valid lecturer.')
     expect(addConsultation).not.toHaveBeenCalled()
+  })
+
+  describe('GET /consultations', () => {
+    test('returns JSON list of the students consultations', async () => {
+      const consultations = [
+        { id: 'abc123', name: 'Project check-in', lecturer: 'Alice Smith', date: '2030-05-06', time: '09:00', isOrganiser: true }
+      ]
+      getConsultationsForStudent.mockResolvedValue(consultations)
+
+      const response = await fetch(`${baseUrl}/consultations`)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.consultations).toEqual(consultations)
+      expect(getConsultationsForStudent).toHaveBeenCalledWith('morris')
+    })
+
+    test('returns 403 when a non-student requests the consultation list', async () => {
+      currentSessionUser = { role: 'lecturer', universityId: 'Wits', username: 'lecturer1' }
+
+      const response = await fetch(`${baseUrl}/consultations`)
+      const data = await response.json()
+
+      expect(response.status).toBe(403)
+      expect(data.error).toBeDefined()
+      expect(getConsultationsForStudent).not.toHaveBeenCalled()
+    })
+
+    test('returns 500 when the database fails', async () => {
+      connectToDatabase.mockRejectedValueOnce(new Error('database unavailable'))
+
+      const response = await fetch(`${baseUrl}/consultations`)
+      const data = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(data.error).toBeDefined()
+    })
+  })
+
+  describe('DELETE /consultations/:id', () => {
+    test('returns success when cancellation succeeds', async () => {
+      const response = await fetch(`${baseUrl}/consultations/abc123`, { method: 'DELETE' })
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(cancelConsultation).toHaveBeenCalledWith('abc123', 'morris')
+    })
+
+    test('returns 403 when a non-student tries to cancel', async () => {
+      currentSessionUser = { role: 'lecturer', universityId: 'Wits', username: 'lecturer1' }
+
+      const response = await fetch(`${baseUrl}/consultations/abc123`, { method: 'DELETE' })
+      const data = await response.json()
+
+      expect(response.status).toBe(403)
+      expect(data.error).toBeDefined()
+      expect(cancelConsultation).not.toHaveBeenCalled()
+    })
+
+    test('returns 404 when the consultation is not found', async () => {
+      cancelConsultation.mockResolvedValue({ success: false, statusCode: 404, reason: 'not-found' })
+
+      const response = await fetch(`${baseUrl}/consultations/abc123`, { method: 'DELETE' })
+      const data = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(data.success).toBe(false)
+      expect(data.error).toBe('Consultation not found.')
+    })
+
+    test('returns 403 when the student is not the organiser', async () => {
+      cancelConsultation.mockResolvedValue({ success: false, statusCode: 403, reason: 'not-organiser' })
+
+      const response = await fetch(`${baseUrl}/consultations/abc123`, { method: 'DELETE' })
+      const data = await response.json()
+
+      expect(response.status).toBe(403)
+      expect(data.success).toBe(false)
+      expect(data.error).toBe('Only the organiser can cancel this consultation.')
+    })
+
+    test('returns 400 when the consultation is in the past', async () => {
+      cancelConsultation.mockResolvedValue({ success: false, statusCode: 400, reason: 'past-consultation' })
+
+      const response = await fetch(`${baseUrl}/consultations/abc123`, { method: 'DELETE' })
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.success).toBe(false)
+      expect(data.error).toBe('Past consultations cannot be cancelled.')
+    })
+
+    test('returns 500 when the database throws', async () => {
+      connectToDatabase.mockRejectedValueOnce(new Error('database unavailable'))
+
+      const response = await fetch(`${baseUrl}/consultations/abc123`, { method: 'DELETE' })
+      const data = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(data.success).toBe(false)
+      expect(data.error).toBeDefined()
+    })
   })
 
   test('re-renders the form when saving the consultation fails', async () => {


### PR DESCRIPTION
Close #51 

**Summary:** Add cancel consultation so student organisers can cancel their upcoming consultations from the home page. This includes a Manage Consultations modal, server-side cancellation with organiser and future-date verification, automatic calendar refresh on success, and unit, integration, and E2E test coverage.

**Key Changes:**

- Added `getConsultationsForStudent` and `cancelConsultation` to `consultation_db`, retrieving upcoming consultations per student and permanently deleting a consultation after verifying the requester is the organiser and the datetime is in the future.
- Added `GET /consultations` returning the student's upcoming consultations as JSON, and `DELETE /consultations/:id` with organiser, role, and future-date guards.
- Added a Manage Consultations button and `<dialog>` modal to the student home page; Cancel buttons render only on consultations the logged-in student organised.
- Added `window.confirm` prompt before submission and a page reload on success to refresh the calendar without additional API calls.
- Added unit, integration, and E2E tests for all new DB functions, routes, and browser interactions.

**Acceptance:**

- A button on the home page opens a modal listing all upcoming consultations the student is involved in.
- Each consultation shows topic, lecturer, date, and time.
- A Cancel button is only shown on consultations the student organised.
- Clicking Cancel shows a confirmation prompt before the cancellation is submitted.
- Only future consultations are listed and can be cancelled.
- Cancelling a consultation frees the time slot so a new consultation can be booked in its place.
- Cancelled consultations no longer appear in the modal, on the home calendar, or on the join consultation page.
- The student receives a success message confirming the cancellation.

**How to test locally:**

- `npm test`
- `npm run lint`
- `npm run test:unit -- tests/unit/models/consultation_db.test.js --runInBand`
- `npm run test:unit -- tests/unit/routes/consultations.test.js --runInBand`
- `npm run test:integration:web -- tests/integration/cancel_consultation.test.js --runInBand`
- `npm run test:e2e -- tests/E2E/cancel_consultation.js`

**Notes:**

- Cancellation deletes the consultation document outright, which automatically frees the slot and removes it from all views without requiring changes to existing queries.
- DB-backed integration and E2E tests require a writable MongoDB test database.

Part of #49 