### PR TITLE
Lecturer cancel

### DIFF
--- a/src/models/consultation_db.js
+++ b/src/models/consultation_db.js
@@ -255,6 +255,7 @@ const getConsultationsForCalendar = async function (username, monthStart, monthE
 
 const CANCEL_RESULT_REASONS = {
   NOT_FOUND: 'not-found',
+  NOT_LECTURER: 'not-lecturer',
   NOT_ORGANISER: 'not-organiser',
   PAST_CONSULTATION: 'past-consultation'
 }
@@ -299,12 +300,14 @@ const getConsultationsForStudent = async function (username) {
 }
 
 /**
- * Deletes a future consultation if the requesting user is its organiser.
+ * Deletes a future consultation if the requesting user owns it.
+ * Students and admins must be the organiser; lecturers must be the assigned lecturer.
  * @param {string} consultationId - Consultation id string.
- * @param {string} organiserId - Username of the requester.
+ * @param {string} userId - Username of the requester.
+ * @param {string} role - Role of the requester ('lecturer' | 'student' | 'admin').
  * @returns {Promise<{success: boolean, statusCode?: number, reason?: string}>} Cancel result.
  */
-const cancelConsultation = async function (consultationId, organiserId) {
+const cancelConsultation = async function (consultationId, userId, role) {
   if (!ObjectId.isValid(consultationId)) {
     return { success: false, statusCode: 404, reason: CANCEL_RESULT_REASONS.NOT_FOUND }
   }
@@ -316,7 +319,11 @@ const cancelConsultation = async function (consultationId, organiserId) {
     return { success: false, statusCode: 404, reason: CANCEL_RESULT_REASONS.NOT_FOUND }
   }
 
-  if (consultation.organiserId !== organiserId) {
+  if (role === 'lecturer') {
+    if (consultation.lecturerId !== userId) {
+      return { success: false, statusCode: 403, reason: CANCEL_RESULT_REASONS.NOT_LECTURER }
+    }
+  } else if (consultation.organiserId !== userId) {
     return { success: false, statusCode: 403, reason: CANCEL_RESULT_REASONS.NOT_ORGANISER }
   }
 

--- a/src/public/scripts/manage_consultations.js
+++ b/src/public/scripts/manage_consultations.js
@@ -35,7 +35,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const lecturer = document.createElement('p')
     lecturer.className = 'dashboard_consultation_meta'
-    lecturer.textContent = `Lecturer: ${consultation.lecturer}`
+    lecturer.textContent = consultation.organiser
+      ? `Organiser: ${consultation.organiser}`
+      : `Lecturer: ${consultation.lecturer}`
     article.appendChild(lecturer)
 
     const dateTime = document.createElement('p')

--- a/src/routes/consultations.js
+++ b/src/routes/consultations.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const { connectToDatabase } = require('../models/db')
-const { addConsultation, cancelConsultation, getConsultationsForStudent, listConsultationsForLecturerOnDate } = require('../models/consultation_db')
+const { addConsultation, cancelConsultation, getConsultationsForStudent, getUpcomingConsultationsForLecturer, listConsultationsForLecturerOnDate } = require('../models/consultation_db')
 const { getLecturerAvailability } = require('../models/lecturer_availability_db')
 const { addMinutesToTime, validateLecturerAvailability, findOverlappingConsultation } = require('../services/consultation_availability_validation')
 const { getUser, searchLecturers } = require('../models/user_db')
@@ -9,6 +9,7 @@ const router = express.Router()
 const DATETIME_LOCAL_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/
 const CANCEL_ERROR_MESSAGES = {
   'not-found': 'Consultation not found.',
+  'not-lecturer': 'Only the assigned lecturer can cancel this consultation.',
   'not-organiser': 'Only the organiser can cancel this consultation.',
   'past-consultation': 'Past consultations cannot be cancelled.'
 }
@@ -294,12 +295,18 @@ router.post('/', async function (req, res) {
 router.get('/', async function (req, res) {
   const { username = '', role = '' } = req.session?.user || {}
 
-  if (role !== 'student' && role !== 'admin') {
-    return res.status(403).json({ error: 'Only students can view their consultations.' })
+  if (role !== 'student' && role !== 'admin' && role !== 'lecturer') {
+    return res.status(403).json({ error: 'Access denied.' })
   }
 
   try {
     await connectToDatabase()
+
+    if (role === 'lecturer') {
+      const consultations = await getUpcomingConsultationsForLecturer(username)
+      return res.json({ consultations: consultations.map(function (c) { return { ...c, isOrganiser: true } }) })
+    }
+
     const consultations = await getConsultationsForStudent(username)
     return res.json({ consultations })
   } catch {
@@ -310,13 +317,13 @@ router.get('/', async function (req, res) {
 router.delete('/:id', async function (req, res) {
   const { username = '', role = '' } = req.session?.user || {}
 
-  if (role !== 'student' && role !== 'admin') {
-    return res.status(403).json({ error: 'Only students can cancel consultations.' })
+  if (role !== 'student' && role !== 'admin' && role !== 'lecturer') {
+    return res.status(403).json({ error: 'Access denied.' })
   }
 
   try {
     await connectToDatabase()
-    const result = await cancelConsultation(req.params.id, username)
+    const result = await cancelConsultation(req.params.id, username, role)
 
     return result.success
       ? res.json({ success: true })

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -35,6 +35,21 @@
         <% } %>
       </section>
 
+    <% } else if (role === 'lecturer' && username) { %>
+      <section class="home_navigation">
+        <h2 class="home_navigation_title">Navigation</h2>
+        <p class="home_navigation_text">Choose an option below.</p>
+        <div class="home_navigation_actions">
+          <a href="/user_profile?user=<%= encodeURIComponent(username) %>">User Profile</a>
+          <a href="/scheduled_consultations">Scheduled Consultations</a>
+          <button type="button" id="manage_consultations_btn" class="home_navigation_primary">Manage Consultations</button>
+        </div>
+      </section>
+    <% } else if (username) { %>
+      <a class="back_link" href="/user_profile?user=<%= encodeURIComponent(username) %>">User Profile</a>
+    <% } %>
+
+    <% if ((role === 'student' || role === 'admin' || role === 'lecturer') && username) { %>
       <dialog id="manage_consultations_dialog" class="manage_dialog">
         <div class="manage_dialog_header">
           <h2 class="manage_dialog_title">My Consultations</h2>
@@ -43,15 +58,6 @@
         <p id="manage_consultations_msg" class="is_hidden" aria-live="polite"></p>
         <div id="manage_consultations_list"></div>
       </dialog>
-    <% } else if (role === 'lecturer' && username) { %>
-      <section class="home_navigation">
-        <h2 class="home_navigation_title">Navigation</h2>
-        <p class="home_navigation_text">Choose an option below.</p>
-        <a href="/user_profile?user=<%= encodeURIComponent(username) %>">User Profile</a>
-        <a href="/scheduled_consultations">Scheduled Consultations</a>
-      </section>
-    <% } else if (username) { %>
-      <a class="back_link" href="/user_profile?user=<%= encodeURIComponent(username) %>">User Profile</a>
     <% } %>
 
     <section class="calendar_section">

--- a/tests/E2E/lecturer_cancel_consultation.js
+++ b/tests/E2E/lecturer_cancel_consultation.js
@@ -1,0 +1,118 @@
+const path = require('node:path')
+const { test, expect } = require('@playwright/test')
+const { connectToDatabase, closeDatabaseConnection, getCollection } = require('../../src/models/db')
+require('dotenv').config({ path: path.resolve(__dirname, '../../.env'), quiet: true })
+
+const SEEDED_STUDENT_USERNAME = 'user'
+const SEEDED_LECTURER_USERNAME = 'user1'
+const PASSWORD = 'password'
+const TEST_ID = `${process.pid}${Date.now()}`
+const TEST_STUDENT_USERNAME = `e2estud${TEST_ID}lectcancel`
+const TEST_LECTURER_USERNAME = `e2elect${TEST_ID}lectcancel`
+
+test.describe('lecturer cancel consultation E2E', () => {
+  test.skip(!process.env.MONGODB_URI, 'Requires a writable MongoDB test database.')
+
+  const futureDatetime = function () {
+    const date = new Date()
+    date.setDate(date.getDate() + 7)
+    date.setHours(9, 0, 0, 0)
+    const pad = (n) => String(n).padStart(2, '0')
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T09:00`
+  }
+
+  const loginAsLecturer = async function (page) {
+    await page.goto('/login')
+    await page.getByRole('textbox', { name: 'Username' }).fill(TEST_LECTURER_USERNAME)
+    await page.getByLabel('Password').fill(PASSWORD)
+    await page.getByRole('button', { name: 'Log In' }).click()
+    await expect(page).toHaveURL(/\/home$/)
+  }
+
+  test.beforeAll(async function () {
+    await connectToDatabase()
+    const users = await getCollection('User')
+    const seededStudent = await users.findOne({ username: SEEDED_STUDENT_USERNAME })
+    const seededLecturer = await users.findOne({ username: SEEDED_LECTURER_USERNAME })
+
+    if (!seededStudent || !seededLecturer) {
+      throw new Error('Seeded users for lecturer cancel consultation E2E tests were not found.')
+    }
+
+    const { _id: _sid, username: _su, email: _se, ...studentFields } = seededStudent
+    const { _id: _lid, username: _lu, email: _le, ...lecturerFields } = seededLecturer
+
+    await users.deleteMany({ username: { $in: [TEST_STUDENT_USERNAME, TEST_LECTURER_USERNAME] } })
+    await users.insertMany([
+      { ...studentFields, email: `${TEST_STUDENT_USERNAME}@example.test`, username: TEST_STUDENT_USERNAME },
+      { ...lecturerFields, email: `${TEST_LECTURER_USERNAME}@example.test`, username: TEST_LECTURER_USERNAME }
+    ])
+  })
+
+  test.afterEach(async function () {
+    await connectToDatabase()
+    await getCollection('Consultation').deleteMany({ lecturerId: TEST_LECTURER_USERNAME })
+  })
+
+  test.afterAll(async function () {
+    await connectToDatabase()
+    await getCollection('Consultation').deleteMany({ lecturerId: TEST_LECTURER_USERNAME })
+    await getCollection('User').deleteMany({ username: { $in: [TEST_STUDENT_USERNAME, TEST_LECTURER_USERNAME] } })
+    await closeDatabaseConnection()
+  })
+
+  test('Manage Consultations button is visible on the lecturer home page', async ({ page }) => {
+    await loginAsLecturer(page)
+
+    await expect(page.getByRole('button', { name: 'Manage Consultations' })).toBeVisible()
+  })
+
+  test('modal shows the consultation with a Cancel button for the assigned lecturer', async ({ page }) => {
+    await connectToDatabase()
+    await getCollection('Consultation').insertOne({
+      attendees: [TEST_STUDENT_USERNAME],
+      capacity: 1,
+      datetime: futureDatetime(),
+      lecturerId: TEST_LECTURER_USERNAME,
+      organiserId: TEST_STUDENT_USERNAME,
+      title: 'E2E Lecturer Cancel Modal Test'
+    })
+
+    await loginAsLecturer(page)
+    await page.getByRole('button', { name: 'Manage Consultations' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toContainText('E2E Lecturer Cancel Modal Test')
+    await expect(dialog.getByRole('button', { name: 'Cancel Consultation' })).toBeVisible()
+  })
+
+  test('confirming the cancel prompt removes the consultation from the database', async ({ page }) => {
+    await connectToDatabase()
+    const { insertedId } = await getCollection('Consultation').insertOne({
+      attendees: [TEST_STUDENT_USERNAME],
+      capacity: 1,
+      datetime: futureDatetime(),
+      lecturerId: TEST_LECTURER_USERNAME,
+      organiserId: TEST_STUDENT_USERNAME,
+      title: 'E2E Lecturer Consultation To Cancel'
+    })
+
+    await loginAsLecturer(page)
+    await page.getByRole('button', { name: 'Manage Consultations' }).click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+
+    page.once('dialog', async function (nativeDialog) {
+      await nativeDialog.accept()
+    })
+
+    await Promise.all([
+      page.waitForNavigation(),
+      page.getByRole('button', { name: 'Cancel Consultation' }).click()
+    ])
+
+    await connectToDatabase()
+    const remaining = await getCollection('Consultation').findOne({ _id: insertedId })
+    expect(remaining).toBeNull()
+  })
+})

--- a/tests/E2E/lecturer_cancel_consultation.js
+++ b/tests/E2E/lecturer_cancel_consultation.js
@@ -5,7 +5,7 @@ require('dotenv').config({ path: path.resolve(__dirname, '../../.env'), quiet: t
 
 const SEEDED_STUDENT_USERNAME = 'user'
 const SEEDED_LECTURER_USERNAME = 'user1'
-const PASSWORD = 'password'
+const LECTURER_PASSWORD = 'password1'
 const TEST_ID = `${process.pid}${Date.now()}`
 const TEST_STUDENT_USERNAME = `e2estud${TEST_ID}lectcancel`
 const TEST_LECTURER_USERNAME = `e2elect${TEST_ID}lectcancel`
@@ -24,7 +24,7 @@ test.describe('lecturer cancel consultation E2E', () => {
   const loginAsLecturer = async function (page) {
     await page.goto('/login')
     await page.getByRole('textbox', { name: 'Username' }).fill(TEST_LECTURER_USERNAME)
-    await page.getByLabel('Password').fill(PASSWORD)
+    await page.getByLabel('Password').fill(LECTURER_PASSWORD)
     await page.getByRole('button', { name: 'Log In' }).click()
     await expect(page).toHaveURL(/\/home$/)
   }

--- a/tests/integration/cancel_consultation.test.js
+++ b/tests/integration/cancel_consultation.test.js
@@ -140,6 +140,54 @@ describe('cancel consultation integration flow', () => {
     expect(data.consultations.some(function (c) { return c.id === insertedId.toString() })).toBe(true)
   })
 
+  RUN_DB_TEST('returns the lecturer upcoming consultations', async function () {
+    await connectToDatabase()
+    const { insertedId } = await getCollection('Consultation').insertOne({
+      attendees: [TEST_STUDENT_USERNAME],
+      capacity: 1,
+      datetime: futureDatetime(),
+      lecturerId: TEST_LECTURER_USERNAME,
+      organiserId: TEST_STUDENT_USERNAME,
+      title: 'Integration lecturer cancel test consultation'
+    })
+
+    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: TEST_LECTURER_USERNAME })
+    const response = await fetch(`${baseUrl}/consultations`, {
+      headers: { cookie: sessionCookie }
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(Array.isArray(data.consultations)).toBe(true)
+    expect(data.consultations.some(function (c) { return c.id === insertedId.toString() })).toBe(true)
+  })
+
+  RUN_DB_TEST('deletes the consultation and returns success when the lecturer cancels', async function () {
+    await connectToDatabase()
+    const { insertedId } = await getCollection('Consultation').insertOne({
+      attendees: [TEST_STUDENT_USERNAME],
+      capacity: 1,
+      datetime: futureDatetime(),
+      lecturerId: TEST_LECTURER_USERNAME,
+      organiserId: TEST_STUDENT_USERNAME,
+      title: 'Consultation to be cancelled by lecturer'
+    })
+
+    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: TEST_LECTURER_USERNAME })
+    const response = await fetch(`${baseUrl}/consultations/${insertedId.toString()}`, {
+      headers: { cookie: sessionCookie },
+      method: 'DELETE'
+    })
+    const data = await response.json()
+
+    await connectToDatabase()
+    const remaining = await getCollection('Consultation').findOne({ _id: insertedId })
+
+    expect(response.status).toBe(200)
+    expect(data.success).toBe(true)
+    expect(remaining).toBeNull()
+  })
+
   RUN_DB_TEST('deletes the consultation and returns success when the organiser cancels', async function () {
     await connectToDatabase()
     const { insertedId } = await getCollection('Consultation').insertOne({

--- a/tests/integration/cancel_consultation.test.js
+++ b/tests/integration/cancel_consultation.test.js
@@ -2,7 +2,8 @@ const http = require('node:http')
 const { closeDatabaseConnection, connectToDatabase, getCollection } = require('../../src/models/db')
 const app = require('../../src/app')
 
-const PASSWORD = 'password'
+const STUDENT_PASSWORD = 'password'
+const LECTURER_PASSWORD = 'password1'
 const SEEDED_STUDENT_USERNAME = 'user'
 const SEEDED_LECTURER_USERNAME = 'user1'
 const TEST_ID = `${process.pid}${Date.now()}`
@@ -129,7 +130,7 @@ describe('cancel consultation integration flow', () => {
       title: 'Integration cancel test consultation'
     })
 
-    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: TEST_STUDENT_USERNAME })
+    const sessionCookie = await loginAs(baseUrl, { password: STUDENT_PASSWORD, username: TEST_STUDENT_USERNAME })
     const response = await fetch(`${baseUrl}/consultations`, {
       headers: { cookie: sessionCookie }
     })
@@ -151,7 +152,7 @@ describe('cancel consultation integration flow', () => {
       title: 'Integration lecturer cancel test consultation'
     })
 
-    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: TEST_LECTURER_USERNAME })
+    const sessionCookie = await loginAs(baseUrl, { password: LECTURER_PASSWORD, username: TEST_LECTURER_USERNAME })
     const response = await fetch(`${baseUrl}/consultations`, {
       headers: { cookie: sessionCookie }
     })
@@ -173,7 +174,7 @@ describe('cancel consultation integration flow', () => {
       title: 'Consultation to be cancelled by lecturer'
     })
 
-    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: TEST_LECTURER_USERNAME })
+    const sessionCookie = await loginAs(baseUrl, { password: LECTURER_PASSWORD, username: TEST_LECTURER_USERNAME })
     const response = await fetch(`${baseUrl}/consultations/${insertedId.toString()}`, {
       headers: { cookie: sessionCookie },
       method: 'DELETE'
@@ -199,7 +200,7 @@ describe('cancel consultation integration flow', () => {
       title: 'Consultation to be cancelled'
     })
 
-    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: TEST_STUDENT_USERNAME })
+    const sessionCookie = await loginAs(baseUrl, { password: STUDENT_PASSWORD, username: TEST_STUDENT_USERNAME })
     const response = await fetch(`${baseUrl}/consultations/${insertedId.toString()}`, {
       headers: { cookie: sessionCookie },
       method: 'DELETE'

--- a/tests/unit/models/consultation_db.test.js
+++ b/tests/unit/models/consultation_db.test.js
@@ -517,6 +517,29 @@ describe('consultation database operations', () => {
       expect(mockConsultationCollection.deleteOne).toHaveBeenCalledWith({ _id: id })
       expect(result).toEqual({ success: true })
     })
+
+    test('returns not-lecturer when the requesting lecturer is not assigned to the consultation', async () => {
+      const id = new ObjectId()
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+      mockConsultationCollection.findOne.mockResolvedValue({ _id: id, datetime: futureDate, lecturerId: 'lecturer2', organiserId: 'student1' })
+
+      const result = await cancelConsultation(id.toString(), 'lecturer1', 'lecturer')
+
+      expect(result).toEqual({ success: false, statusCode: 403, reason: CANCEL_RESULT_REASONS.NOT_LECTURER })
+      expect(mockConsultationCollection.deleteOne).not.toHaveBeenCalled()
+    })
+
+    test('deletes the consultation and returns success when the assigned lecturer cancels', async () => {
+      const id = new ObjectId()
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 16)
+      mockConsultationCollection.findOne.mockResolvedValue({ _id: id, datetime: futureDate, lecturerId: 'lecturer1', organiserId: 'student1' })
+      mockConsultationCollection.deleteOne.mockResolvedValue({ deletedCount: 1 })
+
+      const result = await cancelConsultation(id.toString(), 'lecturer1', 'lecturer')
+
+      expect(mockConsultationCollection.deleteOne).toHaveBeenCalledWith({ _id: id })
+      expect(result).toEqual({ success: true })
+    })
   })
 
   test('searchConsultationsForStudent only returns consultations in the future', async () => {

--- a/tests/unit/routes/consultations.test.js
+++ b/tests/unit/routes/consultations.test.js
@@ -2,6 +2,7 @@ jest.mock('../../../src/models/consultation_db', () => ({
   addConsultation: jest.fn(),
   cancelConsultation: jest.fn(),
   getConsultationsForStudent: jest.fn(),
+  getUpcomingConsultationsForLecturer: jest.fn(),
   listConsultationsForLecturerOnDate: jest.fn()
 }))
 
@@ -22,7 +23,7 @@ const http = require('node:http')
 const path = require('node:path')
 const express = require('express')
 
-const { addConsultation, cancelConsultation, getConsultationsForStudent, listConsultationsForLecturerOnDate } = require('../../../src/models/consultation_db')
+const { addConsultation, cancelConsultation, getConsultationsForStudent, getUpcomingConsultationsForLecturer, listConsultationsForLecturerOnDate } = require('../../../src/models/consultation_db')
 const { connectToDatabase } = require('../../../src/models/db')
 const { getLecturerAvailability } = require('../../../src/models/lecturer_availability_db')
 const { getUser, searchLecturers } = require('../../../src/models/user_db')
@@ -114,6 +115,7 @@ describe('consultations route', () => {
     addConsultation.mockResolvedValue({ acknowledged: true, insertedId: 'consultation-id' })
     cancelConsultation.mockResolvedValue({ success: true })
     getConsultationsForStudent.mockResolvedValue([])
+    getUpcomingConsultationsForLecturer.mockResolvedValue([])
     listConsultationsForLecturerOnDate.mockResolvedValue([])
     connectToDatabase.mockResolvedValue(undefined)
     getLecturerAvailability.mockResolvedValue({
@@ -309,6 +311,22 @@ describe('consultations route', () => {
       expect(response.status).toBe(500)
       expect(data.error).toBeDefined()
     })
+
+    test('returns JSON list of the lecturer consultations with isOrganiser set to true', async () => {
+      currentSessionUser = { role: 'lecturer', universityId: 'Wits', username: 'lecturer1' }
+      const consultations = [
+        { date: '2030-05-06', id: 'abc123', name: 'Project check-in', organiser: 'Morris Molefe', time: '09:00' }
+      ]
+      getUpcomingConsultationsForLecturer.mockResolvedValue(consultations)
+
+      const response = await fetch(`${baseUrl}/consultations`)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.consultations[0].isOrganiser).toBe(true)
+      expect(getUpcomingConsultationsForLecturer).toHaveBeenCalledWith('lecturer1')
+      expect(getConsultationsForStudent).not.toHaveBeenCalled()
+    })
   })
 
   describe('DELETE /consultations/:id', () => {
@@ -374,6 +392,29 @@ describe('consultations route', () => {
       expect(response.status).toBe(500)
       expect(data.success).toBe(false)
       expect(data.error).toBeDefined()
+    })
+
+    test('returns success when the assigned lecturer cancels', async () => {
+      currentSessionUser = { role: 'lecturer', universityId: 'Wits', username: 'lecturer1' }
+
+      const response = await fetch(`${baseUrl}/consultations/abc123`, { method: 'DELETE' })
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(cancelConsultation).toHaveBeenCalledWith('abc123', 'lecturer1', 'lecturer')
+    })
+
+    test('returns 403 when the lecturer is not assigned to the consultation', async () => {
+      currentSessionUser = { role: 'lecturer', universityId: 'Wits', username: 'lecturer1' }
+      cancelConsultation.mockResolvedValue({ success: false, statusCode: 403, reason: 'not-lecturer' })
+
+      const response = await fetch(`${baseUrl}/consultations/abc123`, { method: 'DELETE' })
+      const data = await response.json()
+
+      expect(response.status).toBe(403)
+      expect(data.success).toBe(false)
+      expect(data.error).toBe('Only the assigned lecturer can cancel this consultation.')
     })
   })
 

--- a/tests/unit/routes/consultations.test.js
+++ b/tests/unit/routes/consultations.test.js
@@ -289,8 +289,8 @@ describe('consultations route', () => {
       expect(getConsultationsForStudent).toHaveBeenCalledWith('morris')
     })
 
-    test('returns 403 when a non-student requests the consultation list', async () => {
-      currentSessionUser = { role: 'lecturer', universityId: 'Wits', username: 'lecturer1' }
+    test('returns 403 when an unauthorized role requests the consultation list', async () => {
+      currentSessionUser = { role: 'guest', universityId: 'Wits', username: 'guest1' }
 
       const response = await fetch(`${baseUrl}/consultations`)
       const data = await response.json()
@@ -318,11 +318,11 @@ describe('consultations route', () => {
 
       expect(response.status).toBe(200)
       expect(data.success).toBe(true)
-      expect(cancelConsultation).toHaveBeenCalledWith('abc123', 'morris')
+      expect(cancelConsultation).toHaveBeenCalledWith('abc123', 'morris', 'student')
     })
 
-    test('returns 403 when a non-student tries to cancel', async () => {
-      currentSessionUser = { role: 'lecturer', universityId: 'Wits', username: 'lecturer1' }
+    test('returns 403 when an unauthorized role tries to cancel', async () => {
+      currentSessionUser = { role: 'guest', universityId: 'Wits', username: 'guest1' }
 
       const response = await fetch(`${baseUrl}/consultations/abc123`, { method: 'DELETE' })
       const data = await response.json()


### PR DESCRIPTION
Close #52 

**Summary:** Allow lecturers to cancel any of their upcoming consultations directly from the home page. This includes server-side authorisation, a shared Manage Consultations modal for the lecturer home page, and full unit, integration, and E2E test coverage.

**Key Changes:**

- Extended `cancelConsultation` in the model to accept a `role` parameter — lecturers are authorised by `lecturerId`, students and admins by `organiserId`, keeping the logic in a single function.
- Updated `GET /consultations` and `DELETE /consultations/:id` to serve lecturers alongside students, returning a `403` with a descriptive message when the lecturer is not assigned to the consultation.
- Added a **Manage Consultations** button to the lecturer navigation section and moved the shared `<dialog>` outside the student-only conditional so both roles use the same modal.
- Updated `buildConsultationCard` to display `Organiser:` when the consultation carries an organiser field (lecturer view) and `Lecturer:` otherwise (student view).
- Added unit, integration, and E2E coverage for the lecturer cancel flow.

**Acceptance:**

- Lecturers can open the Manage Consultations modal from their home page.
- All upcoming consultations for the lecturer are listed, each with a Cancel button.
- Cancelling a consultation reloads the page and removes the slot from the calendar.
- A lecturer cannot cancel a consultation assigned to a different lecturer.
- Student cancel behaviour is unchanged.

**How to test locally:**

- `npm test`
- `npm run lint`
- `npm run test:unit -- tests/unit/models/consultation_db.test.js --runInBand`
- `npm run test:unit -- tests/unit/routes/consultations.test.js --runInBand`
- `npm run test:integration:web -- tests/integration/cancel_consultation.test.js --runInBand`
- `npm run test:e2e -- tests/E2E/lecturer_cancel_consultation.js`

**Notes:**

- The unified `cancelConsultation` function replaces the previously separate `cancelConsultationAsLecturer` approach, reducing duplication while keeping the authorisation rules explicit via the `role` branch.
- DB-backed integration and E2E tests require a writable MongoDB test database.

Part of #49 
finally closes #49 