### PR TITLE
Wits seeder

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ The application is built with a server-rendered Node.js and Express stack, backe
 
 2. [x] **Completed**
 
-3. [ ] **In Progress**
+3. [x] **Completed**
 
-4. [ ] **Unstarted**
+4. [ ] **In Progress**
 
 ---
 
@@ -90,6 +90,38 @@ The application is hosted on Render and accessible at:
    ```
 
 The app will be available at `http://localhost:8080`.
+
+---
+
+## Database Seeding
+
+The seed script populates the database with real Wits University faculties, schools, and lecturer accounts scraped from [wits.ac.za](https://www.wits.ac.za). It is safe to run more than once — existing lecturer records are never duplicated or modified.
+
+### Prerequisites
+
+- `MONGODB_URI` must be set in your `.env` file (see [Installation](#installation))
+- An active internet connection (the script fetches live data from the Wits website)
+
+### Running the seed script
+
+```sh
+node scripts/seed_wits_data.js
+```
+
+### What it creates
+
+| Collection | Records added |
+|---|---|
+| `University` | University of the Witwatersrand |
+| `Faculty` | Commerce Law & Management, Engineering & the Built Environment, Health Sciences, Science |
+| `School` | All schools within the seeded faculties |
+| `User` | One lecturer account per scraped staff member |
+
+Each lecturer account is created with the fields `firstName`, `lastName`, `username`, `email`, `passwordHash`, `role`, `universityId`, `facultyId`, and `schoolId`. The default password for each account is the initials portion of the username (e.g. username `CDKatWits` → password `CDK`). If multiple lecturers share the same initials, a counter suffix is appended to both: the second becomes username `CDKatWits2` → password `CDK2`, the third `CDKatWits3` → password `CDK3`, and so on.
+
+> **Note:** The Humanities faculty and certain dispersed Health Sciences schools (Clinical Medicine, Oral Health Sciences, Pathology) are excluded from seeding as their staff pages are not structured for automated scraping.
+
+> **Re-runs:** If all lecturers scraped from a school already exist in the database, the script will report `0 lecturers seeded` for that school. This is expected behaviour — no duplicates are created.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "@types/node": "^25.6.0",
+        "axios": "^1.16.1",
         "c8": "^11.0.0",
+        "cheerio": "^1.2.0",
         "jest": "^30.3.0",
         "standard": "^17.1.2"
       }
@@ -1741,6 +1743,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2016,6 +2031,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2030,6 +2052,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2182,6 +2217,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "2.1.0",
@@ -2592,6 +2634,50 @@
         "node": ">=10"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -2731,6 +2817,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2798,6 +2897,36 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/data-view-buffer": {
@@ -2939,6 +3068,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2969,6 +3108,65 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -3059,6 +3257,46 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -4284,6 +4522,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -4315,6 +4574,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -4724,6 +5023,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -4742,6 +5074,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -6597,6 +6943,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/oauth": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
@@ -6899,6 +7258,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -7301,6 +7713,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {
@@ -8702,6 +9124,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
@@ -8854,6 +9286,43 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
+    "axios": "^1.16.1",
     "c8": "^11.0.0",
+    "cheerio": "^1.2.0",
     "jest": "^30.3.0",
     "standard": "^17.1.2"
   }

--- a/scripts/seed_wits_data.js
+++ b/scripts/seed_wits_data.js
@@ -1,0 +1,456 @@
+require('dotenv').config()
+const axios = require('axios')
+const cheerio = require('cheerio')
+const { MongoClient } = require('mongodb')
+const { hashPassword } = require('../src/utils/password')
+
+const BASE_URL = 'https://www.wits.ac.za'
+const UNIVERSITY_NAME = 'University of the Witwatersrand'
+const REQUEST_DELAY_MS = 700
+
+const TITLE_PATTERN = /^(?:(?:adjunct|associate|emeritus)\s+)?(?:prof(?:essor)?\.?|a\/prof\.?|doctor|dr\.?|mr\.?|ms\.?|mrs\.?|rev\.?)\s+/i
+
+const sleep = function (ms) {
+  return new Promise(function (resolve) { setTimeout(resolve, ms) })
+}
+
+const fetchPage = async function (url) {
+  const response = await axios.get(url, {
+    headers: { 'User-Agent': 'LetsTalkSeedScript/1.0' },
+    timeout: 15000
+  })
+  return cheerio.load(response.data)
+}
+
+const stripTitles = function (name) {
+  let cleaned = name.trim()
+    .replace(/\s*\([^)]*\)/g, '') // remove (Dr), (nickname), etc.
+    .replace(/\s+[Hh]ead\s+[Oo]f\b.*/i, '') // remove "Head of Division: ..." role suffix
+    .trim()
+  let previous
+  do {
+    previous = cleaned
+    cleaned = cleaned.replace(TITLE_PATTERN, '').trim()
+  } while (cleaned !== previous)
+  return cleaned
+}
+
+const getInitials = function (cleanedName) {
+  return cleanedName
+    .split(/\s+/)
+    .filter(function (word) { return /^[A-Za-z]/.test(word) })
+    .map(function (word) { return word[0].toUpperCase() })
+    .join('')
+}
+
+const parseName = function (cleanedName) {
+  const parts = cleanedName.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 1) {
+    return { firstName: parts[0], lastName: parts[0] }
+  }
+  return {
+    firstName: parts.slice(0, -1).join(' '),
+    lastName: parts[parts.length - 1]
+  }
+}
+
+const makeUsername = function (initials, usedUsernames) {
+  let candidate = `${initials}atWits`
+  let counter = 2
+  while (usedUsernames.has(candidate)) {
+    candidate = `${initials}atWits${counter}`
+    counter++
+  }
+  return candidate
+}
+
+const makePassword = function (username) {
+  return username.replace('atWits', '')
+}
+
+const AFFILIATED_STAFF_URLS = {
+  'https://www.wbs.ac.za/': 'https://www.wbs.ac.za/faculty',
+  'https://www.wsg.ac.za/': 'https://www.wsg.ac.za/people'
+}
+
+// Schools whose staff page is not at the default <schoolPath>staff/ URL
+const SCHOOL_STAFF_URL_OVERRIDES = {
+  '/gaes/': `${BASE_URL}/gaes/staff/academic-staff/`,
+  '/mia/': `${BASE_URL}/mia/about-the-school/staff/`,
+  '/sef/': `${BASE_URL}/sef/people/`
+}
+
+// Schools where only one named accordion section should be seeded
+const SCHOOLS_H4_SECTION_FILTER = {
+  '/miningeng/': /visiting and emeritus/i
+}
+
+// Schools whose staff is too dispersed to seed — existing records are removed
+const SCHOOLS_TO_SKIP = new Set(['/clinicalmed/', '/oralhealthsciences/', '/pathology/'])
+
+// Faculties too dispersed to seed — all schools in these faculties are skipped and removed
+const FACULTIES_TO_SKIP = new Set(['Humanities'])
+
+// Per-school name exclusions applied after title-stripping (e.g. deceased staff listed in memoriam)
+const SCHOOL_NAME_EXCLUSIONS = {
+  '/geosciences/': new Set(['Lewis Ashwal'])
+}
+
+const ACADEMIC_ROLE_PATTERN = /lecturer|professor|research|head of|curator|emeritus/i
+
+const scrapePhysiology = async function (url) {
+  const $ = await fetchPage(url)
+  const names = []
+  const tabHref = $('ul.tabs a').filter(function () {
+    return /academic staff/i.test($(this).text())
+  }).attr('href')
+  if (!tabHref) return names
+  const tabId = tabHref.slice(1)
+  $(`[id="${tabId}"] p strong`).each(function (_, el) {
+    const name = $(el).text().trim()
+    if (name) names.push(name)
+  })
+  return names
+}
+
+const scrapeAnatomicalSciences = async function (url) {
+  const $ = await fetchPage(url)
+  const names = []
+  $('table td').each(function (_, td) {
+    const strong = $(td).children('strong')
+    if (!strong.length) return
+    const name = strong.text().trim()
+    if (!name) return
+    let role = ''
+    $(td).closest('tr').nextAll('tr').slice(0, 5).each(function (_, tr) {
+      const text = $(tr).text().trim()
+      if (text && !/^(tel:|email:|fax:|&nbsp;)/i.test(text) && text.length > 2) {
+        role = text; return false
+      }
+    })
+    if (ACADEMIC_ROLE_PATTERN.test(role)) names.push(name)
+  })
+  return names
+}
+
+const scrapeTherapeuticSciences = function ($) {
+  const names = []
+  $('h5').each(function (_, el) {
+    const pText = $(el).next('p').text().trim()
+    if (/^(senior\s+)?lecturer/i.test(pText)) {
+      const name = $(el).text().trim()
+      if (name) names.push(name)
+    }
+  })
+  return names
+}
+
+const normalizeSchoolPath = function (href) {
+  if (!href) return null
+  if (href.startsWith('/')) return href
+  const witsRelative = href.match(/^https?:\/\/www\.wits\.ac\.za(\/.*)/i)
+  if (witsRelative) return witsRelative[1]
+  // Normalise http → https so AFFILIATED_STAFF_URLS keys always match
+  const normalised = href.replace(/^http:\/\//i, 'https://')
+  if (AFFILIATED_STAFF_URLS[normalised]) return normalised
+  return null
+}
+
+const scrapeFacultiesAndSchools = async function () {
+  const $ = await fetchPage(`${BASE_URL}/faculties-and-schools/`)
+  const faculties = []
+
+  $('div.feature-block').each(function (_, block) {
+    const facultyName = $(block).find('h2 a').text().trim()
+    const seenPaths = new Set()
+    const schools = []
+
+    $(block).find('div.feature-content strong a').each(function (_, link) {
+      const schoolName = $(link).text().trim()
+      const schoolPath = normalizeSchoolPath($(link).attr('href'))
+      if (schoolName && schoolPath && !seenPaths.has(schoolPath)) {
+        seenPaths.add(schoolPath)
+        schools.push({ name: schoolName, path: schoolPath })
+      }
+    })
+
+    if (facultyName) {
+      faculties.push({ name: facultyName, schools })
+    }
+  })
+
+  return faculties
+}
+
+const scrapeStaffNamesAffiliated = async function (staffUrl) {
+  try {
+    const names = []
+    let currentUrl = staffUrl
+    while (currentUrl) {
+      const $ = await fetchPage(currentUrl)
+      // If the page has an "Academic Staff" heading, scope collection to that section only.
+      // Otherwise (e.g. WBS which has no such heading) collect all h3 elements.
+      const hasAcademicSection = $('h2').filter(function () {
+        return /academic staff/i.test($(this).text())
+      }).length > 0
+      let inSection = !hasAcademicSection
+
+      $('h2, h3').each(function (_, el) {
+        const tag = $(el)[0].tagName.toLowerCase()
+        const text = $(el).text().trim()
+        if (tag === 'h2') {
+          if (hasAcademicSection) inSection = /academic staff/i.test(text)
+          return
+        }
+        if (inSection && text.includes(' ') && !text.includes('?')) names.push(text)
+      })
+
+      const nextHref = $('a[rel="next"]').attr('href')
+      currentUrl = nextHref ? new URL(nextHref, currentUrl).href : null
+      if (nextHref) await sleep(REQUEST_DELAY_MS)
+    }
+    return names
+  } catch {
+    return []
+  }
+}
+
+const PEOPLE_LINK_SELECTOR = 'a[href*="/people/academic-a-z-listing/"], a[href*="/people/professional-and-administrative-a-z-listing/"]'
+
+const CHEMISTRY_LINK_SELECTOR = 'a[href*="/staff/academic-a-z-listing/"]'
+
+// Chemistry: most staff linked via /staff/academic-a-z-listing/; a few emeritus are plain <p><strong> with title prefix
+const scrapeChemistry = function ($) {
+  const names = []
+  const seen = new Set()
+  $('p').each(function (_, el) {
+    const link = $(el).find(CHEMISTRY_LINK_SELECTOR)
+    if (link.length) {
+      const name = link.find('strong').text().trim() || link.text().trim()
+      if (name && !seen.has(name)) { seen.add(name); names.push(name) }
+      return
+    }
+    $(el).children('strong').each(function (_, strong) {
+      const text = $(strong).text().trim()
+      if (TITLE_PATTERN.test(text) && !seen.has(text)) { seen.add(text); names.push(text) }
+    })
+  })
+  return names
+}
+
+// GAES: names in <li><a people-link><strong>Name</strong></a></li>
+const scrapeGAES = function ($) {
+  const names = []
+  const seen = new Set()
+  $(PEOPLE_LINK_SELECTOR).each(function (_, link) {
+    if (!$(link).closest('li').length) return
+    const name = $(link).find('strong').text().trim() || $(link).text().trim()
+    if (name && !seen.has(name)) { seen.add(name); names.push(name) }
+  })
+  return names
+}
+
+const scrapeStaffNames = async function (schoolPath) {
+  if (SCHOOLS_TO_SKIP.has(schoolPath)) return []
+
+  const affiliatedUrl = AFFILIATED_STAFF_URLS[schoolPath]
+  if (affiliatedUrl) return scrapeStaffNamesAffiliated(affiliatedUrl)
+
+  if (schoolPath === '/biomedicalsciences/') {
+    await sleep(REQUEST_DELAY_MS)
+    const [physNames, anatNames] = await Promise.all([
+      scrapePhysiology(`${BASE_URL}/physiology/staff/`),
+      scrapeAnatomicalSciences(`${BASE_URL}/anatomicalsciences/staff/`)
+    ])
+    const seen = new Set()
+    return [...physNames, ...anatNames].filter(function (n) {
+      return n && !seen.has(n) && seen.add(n)
+    })
+  }
+
+  const url = SCHOOL_STAFF_URL_OVERRIDES[schoolPath] || `${BASE_URL}${schoolPath}staff/`
+  try {
+    const $ = await fetchPage(url)
+
+    if (schoolPath === '/chemistry/') return scrapeChemistry($)
+    if (schoolPath === '/gaes/') return scrapeGAES($)
+    if (schoolPath === '/therapeuticsciences/') return scrapeTherapeuticSciences($)
+
+    const names = []
+
+    // Pass 1: standard Wits layout — names in <p> or <h5> linking to a people listing
+    // (h5 covers SOAP / Architecture and Planning)
+    $('p, h5').each(function (_, el) {
+      const link = $(el).find(PEOPLE_LINK_SELECTOR)
+      if (!link.length) return
+      const rawName = link.find('strong').text().trim() || link.text().trim()
+      if (rawName) names.push(rawName)
+    })
+
+    if (names.length > 0) return names
+
+    // Pass 2: card-based layout — name in .card-heading inside a people link (ChemMet)
+    const cardSeen = new Set()
+    $(PEOPLE_LINK_SELECTOR).each(function (_, el) {
+      const name = $(el).find('.card-heading').text().trim()
+      if (name && !cardSeen.has(name)) { cardSeen.add(name); names.push(name) }
+    })
+
+    if (names.length > 0) return names
+
+    // Pass 3: h4-based layouts (SBS, SEF, Mining Engineering)
+    const seen = new Set()
+    const sectionFilter = SCHOOLS_H4_SECTION_FILTER[schoolPath]
+
+    if (sectionFilter) {
+      // Collect h4s only from the matching accordion section
+      $('dd.accordion-navigation').each(function (_, dd) {
+        if (sectionFilter.test($(dd).find('> a').first().text())) {
+          $(dd).find('h4').each(function (_, h4) {
+            const text = $(h4).text().trim()
+            if (text && !seen.has(text)) { seen.add(text); names.push(text) }
+          })
+        }
+      })
+    } else {
+      // Collect h4s before any h3 section header (admin/service sections),
+      // plus any h4 that links directly to a people listing (e.g. visiting fellows).
+      let stopPlain = false
+      $('h3, h4').each(function (_, el) {
+        const tag = $(el)[0].tagName.toLowerCase()
+        const text = $(el).text().trim()
+        if (tag === 'h3') { stopPlain = true; return }
+        const link = $(el).find(PEOPLE_LINK_SELECTOR)
+        if (link.length) {
+          const name = link.find('strong').text().trim() || link.text().trim()
+          if (name && !seen.has(name)) { seen.add(name); names.push(name) }
+          return
+        }
+        if (!stopPlain && text && !seen.has(text)) { seen.add(text); names.push(text) }
+      })
+    }
+
+    return names
+  } catch {
+    return []
+  }
+}
+
+const run = async function () {
+  if (!process.env.MONGODB_URI) {
+    console.error('MONGODB_URI is not set in .env')
+    process.exit(1)
+  }
+
+  const client = new MongoClient(process.env.MONGODB_URI)
+  await client.connect()
+  const db = client.db('LetsTalk')
+
+  const universitiesCol = db.collection('University')
+  const facultiesCol = db.collection('Faculty')
+  const schoolsCol = db.collection('School')
+  const usersCol = db.collection('User')
+
+  const universityDoc = await universitiesCol.findOneAndUpdate(
+    { name: UNIVERSITY_NAME },
+    { $setOnInsert: { city: 'Johannesburg', country: 'South Africa', name: UNIVERSITY_NAME } },
+    { upsert: true, returnDocument: 'after' }
+  )
+  const universityId = universityDoc._id
+  console.log(`University: ${UNIVERSITY_NAME}`)
+
+  const usedUsernames = new Set(
+    (await usersCol.find({}, { projection: { username: 1 } }).toArray())
+      .map(function (u) { return u.username })
+  )
+
+  const existingLecturerKeys = new Set(
+    (await usersCol.find({ role: 'lecturer' }, { projection: { firstName: 1, lastName: 1, schoolId: 1 } }).toArray())
+      .map(function (u) { return `${u.firstName}|${u.lastName}|${u.schoolId}` })
+  )
+
+  const facultyData = await scrapeFacultiesAndSchools()
+  console.log(`Scraped ${facultyData.length} faculties\n`)
+
+  for (const faculty of facultyData) {
+    if (FACULTIES_TO_SKIP.has(faculty.name)) {
+      console.log(`Faculty: ${faculty.name} — skipped`)
+      continue
+    }
+
+    const facultyDoc = await facultiesCol.findOneAndUpdate(
+      { name: faculty.name },
+      { $setOnInsert: { name: faculty.name, universityId, universityName: UNIVERSITY_NAME } },
+      { upsert: true, returnDocument: 'after' }
+    )
+    const facultyId = facultyDoc._id
+    console.log(`Faculty: ${faculty.name}`)
+
+    for (const school of faculty.schools) {
+      await sleep(REQUEST_DELAY_MS)
+
+      if (SCHOOLS_TO_SKIP.has(school.path)) {
+        console.log(`  School: ${school.name} — skipped`)
+        continue
+      }
+
+      await schoolsCol.findOneAndUpdate(
+        { name: school.name },
+        { $setOnInsert: { facultyId, facultyName: faculty.name, name: school.name, universityId, universityName: UNIVERSITY_NAME } },
+        { upsert: true, returnDocument: 'after' }
+      )
+      console.log(`  School: ${school.name}`)
+
+      const rawNames = await scrapeStaffNames(school.path)
+      await sleep(REQUEST_DELAY_MS)
+
+      let addedCount = 0
+      const exclusions = SCHOOL_NAME_EXCLUSIONS[school.path] || new Set()
+
+      for (const rawName of rawNames) {
+        const cleanedName = stripTitles(rawName)
+        if (exclusions.has(cleanedName)) continue
+        const initials = getInitials(cleanedName)
+        if (!initials) continue
+
+        const { firstName, lastName } = parseName(cleanedName)
+        if (existingLecturerKeys.has(`${firstName}|${lastName}|${school.name}`)) continue
+        const username = makeUsername(initials, usedUsernames)
+        usedUsernames.add(username)
+
+        const password = makePassword(username)
+        const passwordHash = await hashPassword(password)
+        const email = `${username.toLowerCase()}@wits.ac.za`
+
+        await usersCol.updateOne(
+          { username },
+          {
+            $setOnInsert: {
+              email,
+              facultyId: faculty.name,
+              firstName,
+              lastName,
+              passwordHash,
+              role: 'lecturer',
+              schoolId: school.name,
+              universityId: UNIVERSITY_NAME,
+              username
+            }
+          },
+          { upsert: true }
+        )
+        addedCount++
+      }
+
+      console.log(`    ${addedCount} lecturers seeded`)
+    }
+  }
+
+  console.log('\nSeed complete.')
+  await client.close()
+}
+
+run().catch(function (err) {
+  console.error('Seed failed:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
Closes #67 

**Summary:** Introduce a seed script that scrapes the Wits University website to populate the database with real faculties, schools, and lecturer accounts. The script handles multiple page structures across schools, generates secure hashed credentials for each lecturer, and is safe to re-run without creating duplicates or modifying existing records.

**Key Changes:**

- Added `scripts/seed_wits_data.js` which scrapes `wits.ac.za/faculties-and-schools/` and each school's staff page using `axios` and `cheerio`, then upserts Faculty, School, and User documents into MongoDB.
- Added `axios` and `cheerio` as dev dependencies to support scraping.
- Implemented school-specific scrapers for pages with non-standard layouts: Chemistry (`/staff/academic-a-z-listing/` links with unlinked emeritus entries), GAES (`<li>`-based listing), Physiology (tab-scoped), Anatomical Sciences (table-based with role filtering), and Therapeutic Sciences (lecturer-role filtering).
- Added `FACULTIES_TO_SKIP` and `SCHOOLS_TO_SKIP` to silently bypass Humanities and dispersed Health Sciences schools (Clinical Medicine, Oral Health Sciences, Pathology).
- Added `SCHOOL_NAME_EXCLUSIONS` to filter specific individuals by name after title-stripping (e.g. deceased staff listed in memoriam).
- Added an `existingLecturerKeys` pre-check keyed on `firstName|lastName|schoolId` so re-runs skip any lecturer already present without generating unused usernames.
- Documented the seed script, credential convention, and re-run behaviour in the README.

**Acceptance:**

- The database contains at least one Faculty, School, and lecturer User entry for each seeded Wits faculty.
- Each lecturer account includes `firstName`, `lastName`, `username`, `email`, `passwordHash`, `role`, `universityId`, `facultyId`, and `schoolId`.
- A seeded lecturer can log in using their initials-based password and access the lecturer dashboard.
- Students can search and filter lecturers by faculty and school, and see real Wits staff.
- Re-running the script reports `0 lecturers seeded` per school when no new staff are found and leaves existing accounts unchanged.
- No duplicate lecturer accounts are created across multiple runs.

**How to test locally:**

- `node scripts/seed_wits_data.js`
- Verify a seeded lecturer can log in and that a student can find and book them.
- Run the script a second time and confirm all schools report `0 lecturers seeded`.

**Notes:**

- Humanities is excluded entirely; Clinical Medicine, Oral Health Sciences, and Pathology are skipped because their staff are dispersed across multiple pages without a scrapeable structure.
- The default password for each lecturer is the initials prefix of their username — `CDKatWits` → `CDK`, `CDKatWits2` → `CDK2`, etc.
- The script requires `MONGODB_URI` in `.env` and an active internet connection.

Part of #65 