### PR TITLE
Register university

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "start": "node src/app.js",
     "check:db": "node src/models/db.js",
+    "refresh:wits-degree-templates": "node scripts/seed_wits_data.js --refresh-degree-templates",
     "postinstall": "npx playwright install",
     "test": "npm run test:coverage:all",
     "test:unit": "jest",

--- a/scripts/seed_wits_data.js
+++ b/scripts/seed_wits_data.js
@@ -1,10 +1,30 @@
 require('dotenv').config()
 const axios = require('axios')
 const cheerio = require('cheerio')
+const fs = require('node:fs/promises')
+const path = require('node:path')
 const { MongoClient } = require('mongodb')
+const { buildWitsDegreeTemplateAuditReport } = require('../src/services/wits_degree_course_templates')
 const { hashPassword } = require('../src/utils/password')
 
 const BASE_URL = 'https://www.wits.ac.za'
+const DEGREE_TEMPLATE_REFRESH_FLAG = '--refresh-degree-templates'
+const DEGREE_TEMPLATE_SERVICE_FILE_PATH = path.join(__dirname, '..', 'src', 'services', 'wits_degree_course_templates.js')
+const DEGREE_TEMPLATE_FACULTY_PAGE_URLS = Object.freeze([
+  'https://www.wits.ac.za/clm/undergraduate-programmes/',
+  'https://www.wits.ac.za/clm/undergraduate-programmes/2/',
+  'https://www.wits.ac.za/clm/undergraduate-programmes/3/',
+  'https://www.wits.ac.za/ebe/undergraduate-programmes/',
+  'https://www.wits.ac.za/ebe/undergraduate-programmes/2/',
+  'https://www.wits.ac.za/ebe/undergraduate-programmes/3/',
+  'https://www.wits.ac.za/health/academic-programmes/undergraduate-programmes/',
+  'https://www.wits.ac.za/health/academic-programmes/undergraduate-programmes/2/',
+  'https://www.wits.ac.za/humanities/undergraduate-programmes/',
+  'https://www.wits.ac.za/humanities/undergraduate-programmes/2/',
+  'https://www.wits.ac.za/humanities/undergraduate-programmes/3/',
+  'https://www.wits.ac.za/law/undergraduate-programmes/',
+  'https://www.wits.ac.za/science/undergraduate/'
+])
 const UNIVERSITY_NAME = 'University of the Witwatersrand'
 const REQUEST_DELAY_MS = 700
 
@@ -182,6 +202,79 @@ const scrapeFacultiesAndSchools = async function () {
   return faculties
 }
 
+const extractProgrammeNamesFromFacultyPage = function ($) {
+  const programmeNames = new Set()
+
+  $('a[href*="/course-finder/undergraduate/"]').each(function (_, link) {
+    const programmeName = $(link).text().replace(/\s+/g, ' ').trim()
+
+    if (!programmeName || /^(apply|read more)$/i.test(programmeName)) {
+      return
+    }
+
+    programmeNames.add(programmeName)
+  })
+
+  return Array.from(programmeNames)
+}
+
+const collectUndergraduateProgrammeNames = async function () {
+  const programmeNames = new Set()
+
+  for (const pageUrl of DEGREE_TEMPLATE_FACULTY_PAGE_URLS) {
+    const $ = await fetchPage(pageUrl)
+
+    extractProgrammeNamesFromFacultyPage($).forEach(function (programmeName) {
+      programmeNames.add(programmeName)
+    })
+
+    await sleep(REQUEST_DELAY_MS)
+  }
+
+  return Array.from(programmeNames).sort()
+}
+
+const updateDegreeTemplateLastUpdated = async function (lastUpdated) {
+  const fileContents = await fs.readFile(DEGREE_TEMPLATE_SERVICE_FILE_PATH, 'utf8')
+  const datePattern = /const DEFAULT_LAST_UPDATED = '\d{4}-\d{2}-\d{2}'/
+
+  if (!datePattern.test(fileContents)) {
+    throw new Error('Could not find DEFAULT_LAST_UPDATED in the Wits degree template module.')
+  }
+
+  const updatedFileContents = fileContents.replace(
+    datePattern,
+    `const DEFAULT_LAST_UPDATED = '${lastUpdated}'`
+  )
+
+  if (updatedFileContents !== fileContents) {
+    await fs.writeFile(DEGREE_TEMPLATE_SERVICE_FILE_PATH, updatedFileContents)
+  }
+}
+
+const refreshWitsDegreeTemplates = async function () {
+  const discoveredProgrammeNames = await collectUndergraduateProgrammeNames()
+  const auditReport = buildWitsDegreeTemplateAuditReport(discoveredProgrammeNames)
+
+  console.log(`Discovered ${auditReport.degreeCount} undergraduate programme labels across ${DEGREE_TEMPLATE_FACULTY_PAGE_URLS.length} Wits faculty pages.`)
+  console.log(`Matched ${auditReport.matchedCount} programme labels to ${auditReport.templateCount} local templates.`)
+
+  if (auditReport.unmatchedCount > 0) {
+    console.log('\nUnmatched programme labels:')
+    auditReport.unmatched.forEach(function (programmeName) {
+      console.log(`- ${programmeName}`)
+    })
+    console.log('\nReview the unmatched labels above and extend src/services/wits_degree_course_templates.js before refreshing again.')
+    return
+  }
+
+  const today = new Date().toISOString().slice(0, 10)
+
+  await updateDegreeTemplateLastUpdated(today)
+
+  console.log(`All discovered programme labels are covered. Refreshed Wits degree template metadata to ${today}.`)
+}
+
 const scrapeStaffNamesAffiliated = async function (staffUrl) {
   try {
     const names = []
@@ -337,6 +430,11 @@ const scrapeStaffNames = async function (schoolPath) {
 }
 
 const run = async function () {
+  if (process.argv.includes(DEGREE_TEMPLATE_REFRESH_FLAG)) {
+    await refreshWitsDegreeTemplates()
+    return
+  }
+
   if (!process.env.MONGODB_URI) {
     console.error('MONGODB_URI is not set in .env')
     process.exit(1)

--- a/src/models/user_db.js
+++ b/src/models/user_db.js
@@ -51,6 +51,29 @@ const updateUserInstitutions = async function (username, {
 }
 
 /**
+ * Updates a user's academic profile by username.
+ * @param {string} username - Username to update.
+ * @param {object} academicProfile - Academic profile fields to store.
+ * @param {string} academicProfile.degree - Updated degree value.
+ * @param {Array<string>} academicProfile.courses - Updated course list.
+ * @returns {Promise<import('mongodb').UpdateResult>} MongoDB update result.
+ */
+const updateUserAcademicProfile = async function (username, {
+  degree,
+  courses
+}) {
+  return usersCollection().updateOne(
+    { username },
+    {
+      $set: {
+        courses,
+        degree
+      }
+    }
+  )
+}
+
+/**
  * Deletes a user document by username.
  * @param {string} username - Username to delete.
  * @returns {Promise<import('mongodb').DeleteResult>} MongoDB delete result.
@@ -189,5 +212,6 @@ module.exports = {
   getUserByGoogleId,
   linkGoogleId,
   searchLecturers,
+  updateUserAcademicProfile,
   updateUserInstitutions
 }

--- a/src/models/user_db.js
+++ b/src/models/user_db.js
@@ -1,9 +1,42 @@
 const { getCollection } = require('./db')
 
 const USER_COLLECTION_NAME = 'User'
+const ACADEMIC_SEARCH_ROLES = ['admin', 'student']
 
 const usersCollection = function () {
   return getCollection(USER_COLLECTION_NAME)
+}
+
+const escapeRegularExpression = function (value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const buildNameSearchConditions = function (query) {
+  if (!query) {
+    return []
+  }
+
+  const escapedQuery = escapeRegularExpression(query)
+  const regex = new RegExp(escapedQuery, 'i')
+  const conditions = [
+    { username: regex },
+    { firstName: regex },
+    { lastName: regex }
+  ]
+
+  const parts = query.trim().split(/\s+/)
+
+  if (parts.length >= 2) {
+    const firstRegex = new RegExp(escapeRegularExpression(parts[0]), 'i')
+    const lastRegex = new RegExp(escapeRegularExpression(parts.slice(1).join(' ')), 'i')
+
+    conditions.push(
+      { firstName: firstRegex, lastName: lastRegex },
+      { firstName: lastRegex, lastName: firstRegex }
+    )
+  }
+
+  return conditions
 }
 
 /**
@@ -132,25 +165,48 @@ const searchLecturers = async function ({ universityId, query = '', facultyId = 
   if (schoolId) filter.schoolId = schoolId
 
   if (query) {
-    const escape = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const regex = new RegExp(escape(query), 'i')
-    const conditions = [
-      { username: regex },
-      { firstName: regex },
-      { lastName: regex }
-    ]
+    filter.$or = buildNameSearchConditions(query)
+  }
 
-    const parts = query.trim().split(/\s+/)
-    if (parts.length >= 2) {
-      const firstRegex = new RegExp(escape(parts[0]), 'i')
-      const lastRegex = new RegExp(escape(parts.slice(1).join(' ')), 'i')
-      conditions.push(
-        { firstName: firstRegex, lastName: lastRegex },
-        { firstName: lastRegex, lastName: firstRegex }
-      )
-    }
+  return usersCollection().find(filter).toArray()
+}
 
-    filter.$or = conditions
+/**
+ * Searches for non-lecturer users within a university, optionally filtering by name, degree, and course.
+ * @param {object} options - Search options.
+ * @param {string} options.universityId - University to scope the search to.
+ * @param {string} [options.query=''] - Name or username substring to match (case-insensitive).
+ * @param {string} [options.degree=''] - Degree substring to match (case-insensitive).
+ * @param {string} [options.course=''] - Course substring to match (case-insensitive).
+ * @param {string} [options.excludeUsername=''] - Username to exclude from the results.
+ * @returns {Promise<object[]>} Array of matching user documents.
+ */
+const searchUsersByAcademicProfile = async function ({
+  universityId,
+  query = '',
+  degree = '',
+  course = '',
+  excludeUsername = ''
+}) {
+  const filter = {
+    role: { $in: ACADEMIC_SEARCH_ROLES },
+    universityId
+  }
+
+  if (excludeUsername) {
+    filter.username = { $ne: excludeUsername }
+  }
+
+  if (degree) {
+    filter.degree = new RegExp(escapeRegularExpression(degree), 'i')
+  }
+
+  if (course) {
+    filter.courses = new RegExp(escapeRegularExpression(course), 'i')
+  }
+
+  if (query) {
+    filter.$or = buildNameSearchConditions(query)
   }
 
   return usersCollection().find(filter).toArray()
@@ -212,6 +268,7 @@ module.exports = {
   getUserByGoogleId,
   linkGoogleId,
   searchLecturers,
+  searchUsersByAcademicProfile,
   updateUserAcademicProfile,
   updateUserInstitutions
 }

--- a/src/public/scripts/consultation_preferences.js
+++ b/src/public/scripts/consultation_preferences.js
@@ -64,3 +64,120 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   })
 })
+
+document.addEventListener('DOMContentLoaded', function () {
+  const form = document.querySelector('.academic_profile_form')
+
+  if (!form) {
+    return
+  }
+
+  const degreeInput = document.getElementById('academic_profile_degree')
+  const coursesInput = document.getElementById('academic_profile_courses')
+  const autofillButton = document.getElementById('academic_profile_autofill')
+  const saveButton = document.getElementById('academic_profile_save')
+  const statusElement = document.getElementById('academic_profile_status')
+
+  if (!degreeInput || !coursesInput || !autofillButton || !saveButton || !statusElement) {
+    return
+  }
+
+  const setStatus = function (message, state = '') {
+    statusElement.classList.remove('academic_profile_status_error', 'academic_profile_status_success')
+
+    if (state) {
+      statusElement.classList.add(`academic_profile_status_${state}`)
+    }
+
+    statusElement.textContent = message
+  }
+
+  const fetchTemplate = async function () {
+    const degree = degreeInput.value.trim()
+
+    if (!degree) {
+      setStatus('Enter a degree to preview suggested Wits courses.')
+      return
+    }
+
+    setStatus('Looking up Wits courses...')
+
+    const params = new URLSearchParams({ degree })
+    const response = await fetch(`${form.dataset.templateUrl}?${params.toString()}`, {
+      headers: {
+        Accept: 'application/json'
+      }
+    }).catch(function () {
+      return null
+    })
+
+    if (!response || !response.ok) {
+      setStatus('Could not load suggested courses right now.', 'error')
+      return
+    }
+
+    const responseBody = await response.json().catch(function () {
+      return null
+    })
+
+    if (!responseBody || !responseBody.matched || !responseBody.template) {
+      setStatus('No Wits course template was found for that degree. You can enter courses manually.')
+      return
+    }
+
+    coursesInput.value = responseBody.template.courses.join('\n')
+    setStatus(`Autofilled ${responseBody.template.courses.length} suggested courses for ${responseBody.template.degreeName}.`, 'success')
+  }
+
+  const saveAcademicProfile = async function () {
+    setStatus('Saving academic profile...')
+
+    const response = await fetch(form.dataset.saveUrl, {
+      body: new URLSearchParams({
+        courses: coursesInput.value,
+        degree: degreeInput.value.trim()
+      }),
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json'
+      },
+      method: 'PATCH'
+    }).catch(function () {
+      return null
+    })
+
+    if (!response) {
+      setStatus('Could not save your academic profile right now.', 'error')
+      return
+    }
+
+    const responseBody = await response.json().catch(function () {
+      return null
+    })
+
+    if (!response.ok || !responseBody || !responseBody.success) {
+      setStatus(responseBody?.error || 'Could not save your academic profile right now.', 'error')
+      return
+    }
+
+    degreeInput.value = responseBody.profile.degree
+    coursesInput.value = responseBody.profile.courses.join('\n')
+    setStatus('Academic profile saved.', 'success')
+  }
+
+  autofillButton.addEventListener('click', fetchTemplate)
+  saveButton.addEventListener('click', saveAcademicProfile)
+
+  degreeInput.addEventListener('change', function () {
+    if (coursesInput.value.trim()) {
+      setStatus('Degree updated. Click Autofill Courses to replace the current course list.')
+      return
+    }
+
+    fetchTemplate()
+  })
+
+  if (degreeInput.value.trim() && !coursesInput.value.trim()) {
+    fetchTemplate()
+  }
+})

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -331,6 +331,32 @@ a {
   margin-left: 0;
 }
 
+.peer_search_section {
+  max-width: 760px;
+  margin: 32px auto 0;
+  text-align: left;
+}
+
+.peer_search_criteria {
+  margin-top: 16px;
+}
+
+.peer_search_flex {
+  margin-top: 12px;
+}
+
+.peer_result_card {
+  align-items: flex-start;
+}
+
+.peer_result_summary {
+  flex: 1;
+}
+
+.peer_result_meta {
+  margin: 6px 0 0;
+}
+
 .calendar_title {
   margin: 0 0 16px;
 }

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -226,6 +226,33 @@ a {
   text-align: left;
 }
 
+.academic_profile_section {
+  max-width: 760px;
+  margin: 32px auto 0;
+  text-align: left;
+}
+
+.academic_profile_actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.academic_profile_status {
+  margin: 0;
+  color: var(--color-secondary);
+  font-size: 0.95rem;
+}
+
+.academic_profile_status_error {
+  color: var(--color-error-text);
+}
+
+.academic_profile_status_success {
+  color: #16a34a;
+}
+
 .profile_detail {
   padding: 14px;
   border: 1px solid var(--color-border);
@@ -569,6 +596,13 @@ a {
   border: 1px solid var(--color-border);
   border-radius: 8px;
   background: var(--color-surface);
+}
+
+@media (max-width: 700px) {
+  .academic_profile_actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 .dashboard_consultations {

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -4,7 +4,7 @@ const express = require('express')
 const { connectToDatabase } = require('../models/db')
 const { getConsultationsForCalendar, getUpcomingConsultationsForFollowedLecturers } = require('../models/consultation_db')
 const { getLecturerAvailability } = require('../models/lecturer_availability_db')
-const { getLecturersByUsernames, getUser, searchLecturers } = require('../models/user_db')
+const { getLecturersByUsernames, getUser, searchLecturers, searchUsersByAcademicProfile } = require('../models/user_db')
 const { buildCurrentMonthCalendar } = require('../utils/calendar')
 
 const router = express.Router()
@@ -38,6 +38,10 @@ const addFollowStateToLecturers = function (lecturers, followedLecturers) {
   })
 }
 
+const buildPeerCoursePreview = function (courses) {
+  return (Array.isArray(courses) ? courses : []).filter(Boolean).slice(0, 3)
+}
+
 router.get('/', async (req, res) => {
   const role = req.session?.user?.role || ''
   const username = req.session?.user?.username || ''
@@ -62,8 +66,12 @@ router.get('/', async (req, res) => {
 
   const query = req.query.q?.trim() || ''
   const facultyId = req.query.facultyId?.trim() || ''
+  const peerCourse = req.query.peerCourse?.trim() || ''
+  const peerDegree = req.query.peerDegree?.trim() || ''
+  const peerQuery = req.query.peerQuery?.trim() || ''
   const schoolId = req.query.schoolId?.trim() || ''
   const page = Math.max(1, parseInt(req.query.page) || 1)
+  const hasPeerSearch = Boolean(peerQuery || peerDegree || peerCourse)
 
   const calendarNow = new Date()
   const calendarYear = calendarNow.getFullYear()
@@ -75,10 +83,19 @@ router.get('/', async (req, res) => {
 
   try {
     await connectToDatabase()
-    const [allLecturers, calendarConsultations, currentUser] = await Promise.all([
+    const [allLecturers, calendarConsultations, currentUser, peerUsers] = await Promise.all([
       searchLecturers({ universityId, query }),
       getConsultationsForCalendar(username, monthStart, monthEnd),
-      role === 'student' ? getUser(username) : Promise.resolve(null)
+      role === 'student' ? getUser(username) : Promise.resolve(null),
+      hasPeerSearch
+        ? searchUsersByAcademicProfile({
+          course: peerCourse,
+          degree: peerDegree,
+          excludeUsername: username,
+          query: peerQuery,
+          universityId
+        })
+        : Promise.resolve([])
     ])
     const followedLecturerIds = role === 'student' ? buildFollowedLecturerIds(currentUser) : []
     const followedLecturerSet = buildFollowedLecturerSet(followedLecturerIds)
@@ -118,16 +135,66 @@ router.get('/', async (req, res) => {
       filteredLecturers.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE),
       followedLecturerSet
     )
+    const peers = peerUsers.map(function (peer) {
+      return {
+        ...peer,
+        coursePreview: buildPeerCoursePreview(peer.courses)
+      }
+    })
 
     if (req.headers.accept?.includes('application/json')) {
-      return res.json({ lecturers, page: currentPage, totalPages })
+      return res.json({ lecturers, page: currentPage, totalPages, peers })
     }
-    return res.render('home', { title, homeTitle, role, username, calendar, consultationsByDate, lecturers, faculties, schools, query, facultyId, schoolId, page: currentPage, totalPages, followedLecturers, followedConsultations })
+    return res.render('home', {
+      title,
+      homeTitle,
+      role,
+      username,
+      calendar,
+      consultationsByDate,
+      lecturers,
+      faculties,
+      schools,
+      query,
+      facultyId,
+      schoolId,
+      page: currentPage,
+      totalPages,
+      followedLecturers,
+      followedConsultations,
+      peerQuery,
+      peerDegree,
+      peerCourse,
+      hasPeerSearch,
+      peers
+    })
   } catch {
     if (req.headers.accept?.includes('application/json')) {
-      return res.json({ lecturers: [], page: 1, totalPages: 0 })
+      return res.json({ lecturers: [], page: 1, totalPages: 0, peers: [] })
     }
-    return res.render('home', { title, homeTitle, role, username, calendar, consultationsByDate: {}, lecturers: [], faculties: [], schools: [], query, facultyId, schoolId, page: 1, totalPages: 0, followedLecturers: [], followedConsultations: [] })
+    return res.render('home', {
+      title,
+      homeTitle,
+      role,
+      username,
+      calendar,
+      consultationsByDate: {},
+      lecturers: [],
+      faculties: [],
+      schools: [],
+      query,
+      facultyId,
+      schoolId,
+      page: 1,
+      totalPages: 0,
+      followedLecturers: [],
+      followedConsultations: [],
+      peerQuery,
+      peerDegree,
+      peerCourse,
+      hasPeerSearch,
+      peers: []
+    })
   }
 })
 

--- a/src/routes/register.js
+++ b/src/routes/register.js
@@ -11,6 +11,11 @@ const PLACEHOLDER_USER_FIELDS = Object.freeze({
   schoolId: 'unassigned'
 })
 
+const EMPTY_ACADEMIC_PROFILE = Object.freeze({
+  courses: [],
+  degree: ''
+})
+
 /**
  * Renders the register page with the supplied view state.
  * @param {import('express').Response} res - Express response object.
@@ -77,6 +82,8 @@ const buildUser = async function ({
   role = ''
 }) {
   return {
+    courses: [...EMPTY_ACADEMIC_PROFILE.courses],
+    degree: EMPTY_ACADEMIC_PROFILE.degree,
     lastName: surname,
     firstName: name,
     role: role.toLowerCase(),

--- a/src/routes/register_complete.js
+++ b/src/routes/register_complete.js
@@ -9,6 +9,11 @@ const PLACEHOLDER_USER_FIELDS = Object.freeze({
   schoolId: 'unassigned'
 })
 
+const EMPTY_ACADEMIC_PROFILE = Object.freeze({
+  courses: [],
+  degree: ''
+})
+
 /**
  * Renders the profile completion page with the supplied view state.
  * @param {import('express').Response} res - Express response object.
@@ -90,6 +95,8 @@ router.post('/', async (req, res) => {
     }
 
     await addUser({
+      courses: [...EMPTY_ACADEMIC_PROFILE.courses],
+      degree: EMPTY_ACADEMIC_PROFILE.degree,
       googleId,
       email,
       firstName,
@@ -102,6 +109,8 @@ router.post('/', async (req, res) => {
     })
 
     req.session.user = {
+      courses: [...EMPTY_ACADEMIC_PROFILE.courses],
+      degree: EMPTY_ACADEMIC_PROFILE.degree,
       role: role.toLowerCase(),
       username,
       universityId: university,

--- a/src/routes/user_profile.js
+++ b/src/routes/user_profile.js
@@ -20,6 +20,18 @@ const WEEKDAYS = [
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 const TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/
 
+const formatCoursesForTextarea = function (courses) {
+  if (Array.isArray(courses)) {
+    return courses.filter(Boolean).join('\n')
+  }
+
+  if (typeof courses === 'string') {
+    return courses.trim()
+  }
+
+  return ''
+}
+
 /**
  * Renders the user profile page with the given view state.
  * @param {object} res - Express response object.
@@ -36,9 +48,11 @@ const renderProfile = function (res, {
   statusCode = 200,
   error = '',
   prefError = '',
+  degree = '',
   emailAddress = '',
   username = '',
   canEdit = false,
+  courses = '',
   university = '',
   faculty = '',
   school = '',
@@ -52,9 +66,11 @@ const renderProfile = function (res, {
     title: 'User Profile',
     error,
     prefError,
+    degree,
     emailAddress,
     username,
     canEdit,
+    courses,
     university,
     faculty,
     school,
@@ -74,9 +90,11 @@ const renderProfile = function (res, {
  */
 const buildProfileViewState = function (user, overrides = {}) {
   return {
+    degree: user?.degree || '',
     emailAddress: user?.email || '',
     username: user?.username || '',
     canEdit: false,
+    courses: formatCoursesForTextarea(user?.courses),
     university: user?.universityId || '',
     faculty: user?.facultyId || '',
     school: user?.schoolId || '',

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,9 +1,13 @@
 const express = require('express')
 const { connectToDatabase } = require('../models/db')
-const { followLecturer, getUser } = require('../models/user_db')
+const { followLecturer, getUser, updateUserAcademicProfile } = require('../models/user_db')
 const { findWitsDegreeCourseTemplate } = require('../services/wits_degree_course_templates')
 
 const router = express.Router()
+
+const ACADEMIC_PROFILE_FORBIDDEN_ERROR = 'You can only update your own academic profile.'
+const ACADEMIC_PROFILE_NOT_FOUND_ERROR = 'User not found.'
+const ACADEMIC_PROFILE_SERVER_ERROR = 'Sorry. We could not save your academic profile right now.'
 
 const FOLLOW_FORBIDDEN_ERROR = 'Only students can follow lecturers.'
 const FOLLOW_INVALID_TARGET_ERROR = 'Please select a valid lecturer.'
@@ -57,6 +61,28 @@ const buildAcademicTemplateResponse = function (template) {
   }
 }
 
+const parseCourses = function (rawCourses) {
+  if (typeof rawCourses !== 'string') {
+    return []
+  }
+
+  const seenCourses = new Set()
+
+  return rawCourses
+    .split(/[\n,]+/)
+    .map(function (course) {
+      return course.trim()
+    })
+    .filter(function (course) {
+      if (!course || seenCourses.has(course)) {
+        return false
+      }
+
+      seenCourses.add(course)
+      return true
+    })
+}
+
 /**
  * Sends a response for the lecturer follow endpoint.
  * Redirects HTML form submissions back to the home page with a flash message,
@@ -97,6 +123,47 @@ router.get('/academic-template', (req, res) => {
   }
 
   return res.json(buildAcademicTemplateResponse(findWitsDegreeCourseTemplate(degree)))
+})
+
+router.patch('/:id', async (req, res) => {
+  const viewer = req.session?.user?.username || ''
+  const targetUsername = req.params.id?.trim() || ''
+  const degree = req.body.degree?.trim() || ''
+  let courses = parseCourses(req.body.courses)
+
+  if (!viewer || viewer !== targetUsername) {
+    return res.status(403).json({ error: ACADEMIC_PROFILE_FORBIDDEN_ERROR, success: false })
+  }
+
+  if (degree && courses.length === 0) {
+    const template = findWitsDegreeCourseTemplate(degree)
+
+    if (template) {
+      courses = template.suggestedCourses
+    }
+  }
+
+  try {
+    await connectToDatabase()
+    const updateResult = await updateUserAcademicProfile(targetUsername, {
+      courses,
+      degree
+    })
+
+    if (!updateResult.matchedCount) {
+      return res.status(404).json({ error: ACADEMIC_PROFILE_NOT_FOUND_ERROR, success: false })
+    }
+
+    return res.json({
+      profile: {
+        courses,
+        degree
+      },
+      success: true
+    })
+  } catch {
+    return res.status(500).json({ error: ACADEMIC_PROFILE_SERVER_ERROR, success: false })
+  }
 })
 
 router.post('/:id/follow', async (req, res) => {

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,6 +1,7 @@
 const express = require('express')
 const { connectToDatabase } = require('../models/db')
 const { followLecturer, getUser } = require('../models/user_db')
+const { findWitsDegreeCourseTemplate } = require('../services/wits_degree_course_templates')
 
 const router = express.Router()
 
@@ -35,6 +36,27 @@ const setFlashMessage = function (req, type, message) {
   req.session.flash = { [type]: message }
 }
 
+const buildAcademicTemplateResponse = function (template) {
+  if (!template) {
+    return {
+      matched: false,
+      template: null
+    }
+  }
+
+  return {
+    matched: true,
+    template: {
+      coursePrefixes: template.coursePrefixes,
+      courses: template.suggestedCourses,
+      degreeName: template.degreeName,
+      faculty: template.faculty,
+      lastUpdated: template.lastUpdated,
+      sourceUrls: template.sourceUrls
+    }
+  }
+}
+
 /**
  * Sends a response for the lecturer follow endpoint.
  * Redirects HTML form submissions back to the home page with a flash message,
@@ -66,6 +88,16 @@ const respond = function (req, res, { statusCode, success, alreadyFollowing = fa
 
   return res.status(statusCode).json({ error, success: false })
 }
+
+router.get('/academic-template', (req, res) => {
+  const degree = req.query.degree?.trim() || ''
+
+  if (!degree) {
+    return res.json(buildAcademicTemplateResponse(null))
+  }
+
+  return res.json(buildAcademicTemplateResponse(findWitsDegreeCourseTemplate(degree)))
+})
 
 router.post('/:id/follow', async (req, res) => {
   const studentUsername = req.session?.user?.username || ''

--- a/src/services/wits_degree_course_templates.js
+++ b/src/services/wits_degree_course_templates.js
@@ -1,0 +1,1539 @@
+const DEFAULT_LAST_UPDATED = '2026-05-17'
+
+const SOURCE_URLS = Object.freeze({
+  clm: 'https://www.wits.ac.za/clm/undergraduate-programmes/',
+  ebe: 'https://www.wits.ac.za/ebe/undergraduate-programmes/',
+  health: 'https://www.wits.ac.za/health/academic-programmes/undergraduate-programmes/',
+  humanities: 'https://www.wits.ac.za/humanities/undergraduate-programmes/',
+  law: 'https://www.wits.ac.za/law/undergraduate-programmes/',
+  science: 'https://www.wits.ac.za/science/undergraduate/'
+})
+
+const normalizeDegreeName = function (degreeName) {
+  if (typeof degreeName !== 'string') {
+    return ''
+  }
+
+  return degreeName
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+const freezeStringArray = function (values) {
+  return Object.freeze(
+    values
+      .filter(function (value) {
+        return typeof value === 'string' && value.trim()
+      })
+      .map(function (value) {
+        return value.trim()
+      })
+  )
+}
+
+const escapeRegularExpression = function (value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const containsAliasPhrase = function (normalizedDegreeName, alias) {
+  const aliasPattern = new RegExp(`(^| )${escapeRegularExpression(alias)}(?= |$)`)
+
+  return aliasPattern.test(normalizedDegreeName)
+}
+
+const buildTemplate = function ({
+  aliases = [],
+  coursePrefixes = [],
+  degreeName,
+  faculty,
+  isFallback = false,
+  sourceUrls = [],
+  suggestedCourses = []
+}) {
+  const normalizedDegreeName = normalizeDegreeName(degreeName)
+  const normalizedAliases = Array.from(new Set(
+    [degreeName, ...aliases]
+      .map(normalizeDegreeName)
+      .filter(Boolean)
+  ))
+
+  return Object.freeze({
+    aliases: Object.freeze(normalizedAliases),
+    coursePrefixes: freezeStringArray(coursePrefixes),
+    degreeName: degreeName.trim(),
+    faculty: faculty.trim(),
+    isFallback,
+    lastUpdated: DEFAULT_LAST_UPDATED,
+    normalizedDegreeName,
+    sourceUrls: freezeStringArray(sourceUrls),
+    suggestedCourses: freezeStringArray(suggestedCourses)
+  })
+}
+
+const DEGREE_TEMPLATE_DEFINITIONS = [
+  {
+    degreeName: 'Bachelor of Science in Engineering',
+    aliases: [
+      'BSc Eng',
+      'BSc Engineering',
+      'Bachelor of Science in Engineering',
+      'Engineering',
+      'BSc Engineering part-time',
+      'Wits Plus BSc Engineering'
+    ],
+    coursePrefixes: ['ENG', 'MATH', 'PHYS'],
+    faculty: 'Engineering and the Built Environment',
+    isFallback: true,
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/wits-plus/bsc-engineering-part-time/'
+    ],
+    suggestedCourses: [
+      'Engineering Mathematics',
+      'Engineering Physics',
+      'Engineering Computing',
+      'Design and Professional Practice',
+      'Materials and Mechanics'
+    ]
+  },
+  {
+    degreeName: 'Aeronautical Engineering',
+    aliases: [
+      'BSc Eng Aeronautical Engineering',
+      'BSc Engineering Aeronautical Engineering',
+      'Aeronautical Engineering'
+    ],
+    coursePrefixes: ['AERO', 'MECH', 'MATH'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/aeronautical-engineering/'
+    ],
+    suggestedCourses: [
+      'Aerodynamics',
+      'Flight Mechanics',
+      'Aircraft Structures',
+      'Propulsion',
+      'Control Systems'
+    ]
+  },
+  {
+    degreeName: 'Architectural Studies',
+    aliases: [
+      'BAS',
+      'Architectural Studies',
+      'Bachelor of Architectural Studies',
+      'Architecture'
+    ],
+    coursePrefixes: ['ARCH', 'PLAN'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/architectural-studies/'
+    ],
+    suggestedCourses: [
+      'Architectural Design Studio',
+      'History of Architecture',
+      'Building Construction',
+      'Design Communication',
+      'Urban Design'
+    ]
+  },
+  {
+    degreeName: 'Biomedical Engineering',
+    aliases: [
+      'BEngSc BME',
+      'BEngSc Biomedical Engineering',
+      'Biomedical Engineering'
+    ],
+    coursePrefixes: ['BME', 'ELEN', 'MATH'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/biomedical-engineering/'
+    ],
+    suggestedCourses: [
+      'Biomedical Instrumentation',
+      'Signals and Systems',
+      'Medical Imaging',
+      'Biomechanics',
+      'Physiology for Engineers'
+    ]
+  },
+  {
+    degreeName: 'Chemical Engineering',
+    aliases: [
+      'BSc Eng Chemical Engineering',
+      'BSc Engineering Chemical Engineering',
+      'Chemical Engineering'
+    ],
+    coursePrefixes: ['CHEM', 'PROC', 'MATH'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/chemical-engineering/'
+    ],
+    suggestedCourses: [
+      'Process Engineering',
+      'Thermodynamics',
+      'Transport Phenomena',
+      'Reaction Engineering',
+      'Process Control'
+    ]
+  },
+  {
+    degreeName: 'Civil Engineering',
+    aliases: [
+      'BSc Eng Civil Engineering',
+      'BSc Engineering Civil Engineering',
+      'Civil Engineering'
+    ],
+    coursePrefixes: ['CIVL', 'GEOM', 'MATH'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/civil-engineering/'
+    ],
+    suggestedCourses: [
+      'Structural Analysis',
+      'Geotechnical Engineering',
+      'Hydraulics',
+      'Transportation Engineering',
+      'Construction Materials'
+    ]
+  },
+  {
+    degreeName: 'Construction Studies',
+    aliases: [
+      'BSc CS',
+      'BSc Construction Studies',
+      'Construction Studies'
+    ],
+    coursePrefixes: ['CONS', 'CM'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/construction-studies/'
+    ],
+    suggestedCourses: [
+      'Construction Technology',
+      'Building Economics',
+      'Project Management',
+      'Construction Law',
+      'Quantity Surveying Fundamentals'
+    ]
+  },
+  {
+    degreeName: 'Bachelor of Engineering Science in Digital Arts',
+    aliases: [
+      'BEngSc Digital Arts',
+      'Engineering Digital Arts',
+      'Bachelor of Engineering Science Digital Arts'
+    ],
+    coursePrefixes: ['DIGA', 'ELEN', 'ARTS'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/digital-arts/'
+    ],
+    suggestedCourses: [
+      'Programming for Games',
+      'Interactive Media',
+      'Game Design',
+      'Digital Animation',
+      'Sound Design'
+    ]
+  },
+  {
+    degreeName: 'Electrical Engineering',
+    aliases: [
+      'BSc Eng Electrical Engineering',
+      'BSc Engineering Electrical Engineering',
+      'Electrical Engineering',
+      'Electrical and Information Engineering'
+    ],
+    coursePrefixes: ['ELEN', 'MATH', 'PHYS'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/electrical-engineering/'
+    ],
+    suggestedCourses: [
+      'ELEN Circuit Theory',
+      'ELEN Electronics',
+      'ELEN Signals and Systems',
+      'ELEN Control Systems',
+      'ELEN Power Systems'
+    ]
+  },
+  {
+    degreeName: 'Industrial Engineering',
+    aliases: [
+      'BSc Eng Industrial Engineering',
+      'BSc Engineering Industrial Engineering',
+      'Industrial Engineering'
+    ],
+    coursePrefixes: ['IE', 'STAT', 'MATH'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/industrial-engineering/'
+    ],
+    suggestedCourses: [
+      'Operations Research',
+      'Production Planning',
+      'Quality Engineering',
+      'Supply Chain Systems',
+      'Systems Simulation'
+    ]
+  },
+  {
+    degreeName: 'Information Engineering',
+    aliases: [
+      'BSc Eng Information Engineering',
+      'BSc Engineering Information Engineering',
+      'Information Engineering'
+    ],
+    coursePrefixes: ['ELEN', 'INFO', 'NETW'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/information-engineering/'
+    ],
+    suggestedCourses: [
+      'Digital Systems',
+      'Computer Networking',
+      'Software Engineering',
+      'Telecommunications',
+      'Embedded Systems'
+    ]
+  },
+  {
+    degreeName: 'Mechanical Engineering',
+    aliases: [
+      'BSc Eng Mechanical Engineering',
+      'BSc Engineering Mechanical Engineering',
+      'Mechanical Engineering'
+    ],
+    coursePrefixes: ['MECH', 'MATS', 'MATH'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/mechanical-engineering/'
+    ],
+    suggestedCourses: [
+      'Thermodynamics',
+      'Fluid Mechanics',
+      'Mechanics of Machines',
+      'Heat Transfer',
+      'Manufacturing Engineering'
+    ]
+  },
+  {
+    degreeName: 'Metallurgy and Materials Engineering',
+    aliases: [
+      'BSc Eng Metallurgy and Materials Engineering',
+      'BSc Engineering Metallurgy and Materials Engineering',
+      'Metallurgy and Materials Engineering',
+      'Materials Engineering'
+    ],
+    coursePrefixes: ['METE', 'MATS', 'CHEM'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/metallurgy-and-materials-engineering/'
+    ],
+    suggestedCourses: [
+      'Extractive Metallurgy',
+      'Materials Science',
+      'Thermodynamics',
+      'Mineral Processing',
+      'Corrosion and Failure'
+    ]
+  },
+  {
+    degreeName: 'Mining Engineering',
+    aliases: [
+      'BSc Eng Mining Engineering',
+      'BSc Engineering Mining Engineering',
+      'Mining Engineering'
+    ],
+    coursePrefixes: ['MINE', 'GEOL', 'MATH'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/mining-engineering/'
+    ],
+    suggestedCourses: [
+      'Mine Surveying',
+      'Rock Engineering',
+      'Mineral Economics',
+      'Ventilation',
+      'Mine Design'
+    ]
+  },
+  {
+    degreeName: 'Property Studies',
+    aliases: [
+      'BSc PS',
+      'BSc Property Studies',
+      'Property Studies'
+    ],
+    coursePrefixes: ['PROP', 'ECON', 'PLAN'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/property-studies/'
+    ],
+    suggestedCourses: [
+      'Property Finance',
+      'Property Valuation',
+      'Real Estate Economics',
+      'Property Investment',
+      'Urban Economics'
+    ]
+  },
+  {
+    degreeName: 'Urban and Regional Planning',
+    aliases: [
+      'BSc URP',
+      'BSc Urban and Regional Planning',
+      'Urban and Regional Planning',
+      'Urban Planning'
+    ],
+    coursePrefixes: ['PLAN', 'GEOG', 'GIS'],
+    faculty: 'Engineering and the Built Environment',
+    sourceUrls: [
+      SOURCE_URLS.ebe,
+      'https://www.wits.ac.za/course-finder/undergraduate/ebe/urban-and-regional-planning/'
+    ],
+    suggestedCourses: [
+      'Planning Theory',
+      'Urban Design',
+      'GIS for Planning',
+      'Housing Policy',
+      'Transport Planning'
+    ]
+  },
+
+  {
+    degreeName: 'Bachelor of Science',
+    aliases: [
+      'BSc',
+      'Bachelor of Science',
+      'Science Degree'
+    ],
+    coursePrefixes: ['MATH', 'STAT', 'PHYS', 'CHEM', 'BIOS'],
+    faculty: 'Science',
+    isFallback: true,
+    sourceUrls: [SOURCE_URLS.science],
+    suggestedCourses: [
+      'Mathematics I',
+      'Scientific Computing',
+      'Physics I',
+      'Chemistry I',
+      'Biological Sciences I'
+    ]
+  },
+  {
+    degreeName: 'Actuarial Science',
+    aliases: [
+      'BSc Actuarial Science',
+      'Bachelor of Science Actuarial Science',
+      'Actuarial Science'
+    ],
+    coursePrefixes: ['ACTL', 'STAT', 'MATH'],
+    faculty: 'Science',
+    sourceUrls: [
+      SOURCE_URLS.science,
+      'https://www.wits.ac.za/course-finder/undergraduate/science/actuarial-science/'
+    ],
+    suggestedCourses: [
+      'Actuarial Science I',
+      'Mathematical Statistics I',
+      'Business Accounting I',
+      'Life Contingencies',
+      'Actuarial Reserving Techniques'
+    ]
+  },
+  {
+    degreeName: 'Biological Sciences',
+    aliases: [
+      'BSc Biological Sciences',
+      'Biological Sciences',
+      'Life Sciences',
+      'Biology'
+    ],
+    coursePrefixes: ['BIOL', 'MCB', 'GENE'],
+    faculty: 'Science',
+    sourceUrls: [
+      SOURCE_URLS.science,
+      'https://www.wits.ac.za/science/undergraduate/biological-sciences-programme/'
+    ],
+    suggestedCourses: [
+      'Cell Biology',
+      'Genetics',
+      'Ecology',
+      'Biochemistry',
+      'Microbiology'
+    ]
+  },
+  {
+    degreeName: 'Chemistry',
+    aliases: [
+      'BSc Chemistry',
+      'Chemistry',
+      'Physical Science Chemistry'
+    ],
+    coursePrefixes: ['CHEM', 'MATH', 'PHYS'],
+    faculty: 'Science',
+    sourceUrls: [
+      SOURCE_URLS.science,
+      'https://www.wits.ac.za/course-finder/undergraduate/science/chemistry/'
+    ],
+    suggestedCourses: [
+      'Chemistry I',
+      'Analytical Chemistry',
+      'Organic Chemistry',
+      'Inorganic Chemistry',
+      'Physical Chemistry'
+    ]
+  },
+  {
+    degreeName: 'Computer Science',
+    aliases: [
+      'BSc Computer Science',
+      'Computer Science',
+      'Computational Applications'
+    ],
+    coursePrefixes: ['COMS', 'MATH', 'STAT'],
+    faculty: 'Science',
+    sourceUrls: [
+      SOURCE_URLS.science,
+      'https://www.wits.ac.za/course-finder/undergraduate/science/computer-science/'
+    ],
+    suggestedCourses: [
+      'Basic Computer Organisation',
+      'Introduction to Algorithms and Programming',
+      'Introduction to Data Structures and Algorithms',
+      'Database Fundamentals',
+      'Computer Networks'
+    ]
+  },
+  {
+    degreeName: 'Environmental Sciences',
+    aliases: [
+      'BSc Environmental Sciences',
+      'Environmental Sciences',
+      'Environmental Science'
+    ],
+    coursePrefixes: ['ENVS', 'GEOG', 'BIOL'],
+    faculty: 'Science',
+    sourceUrls: [
+      SOURCE_URLS.science,
+      'https://www.wits.ac.za/science/undergraduate/earth-sciences/'
+    ],
+    suggestedCourses: [
+      'Environmental Systems',
+      'Ecology',
+      'GIS',
+      'Climate Change Studies',
+      'Conservation Biology'
+    ]
+  },
+  {
+    degreeName: 'Geosciences',
+    aliases: [
+      'BSc Geosciences',
+      'Geosciences',
+      'Earth Sciences',
+      'Geology',
+      'Archaeology and Geography'
+    ],
+    coursePrefixes: ['GEOL', 'GEOG', 'GIS'],
+    faculty: 'Science',
+    sourceUrls: [
+      SOURCE_URLS.science,
+      'https://www.wits.ac.za/science/undergraduate/earth-sciences/'
+    ],
+    suggestedCourses: [
+      'Physical Geology',
+      'Mineralogy',
+      'Geomorphology',
+      'GIS for Earth Sciences',
+      'Environmental Geoscience'
+    ]
+  },
+  {
+    degreeName: 'Mathematics',
+    aliases: [
+      'BSc Mathematics',
+      'Mathematics',
+      'Mathematical Sciences'
+    ],
+    coursePrefixes: ['MATH', 'STAT'],
+    faculty: 'Science',
+    sourceUrls: [
+      SOURCE_URLS.science,
+      'https://www.wits.ac.za/science/undergraduate/mathematical-sciences/'
+    ],
+    suggestedCourses: [
+      'Algebra I',
+      'Calculus I',
+      'Linear Algebra',
+      'Differential Equations',
+      'Abstract Mathematics'
+    ]
+  },
+  {
+    degreeName: 'Physics',
+    aliases: [
+      'BSc Physics',
+      'Physics',
+      'Physical Science Physics',
+      'Astronomy',
+      'Astrophysics'
+    ],
+    coursePrefixes: ['PHYS', 'MATH'],
+    faculty: 'Science',
+    sourceUrls: [
+      SOURCE_URLS.science,
+      'https://www.wits.ac.za/course-finder/undergraduate/science/physics/'
+    ],
+    suggestedCourses: [
+      'Physics I',
+      'Quantum Mechanics',
+      'Waves and Modern Optics',
+      'Statistical Physics',
+      'Advanced Experimental Physics'
+    ]
+  },
+  {
+    degreeName: 'Statistical Science',
+    aliases: [
+      'BSc Statistics',
+      'Statistics',
+      'Statistical Science',
+      'Mathematical Statistics'
+    ],
+    coursePrefixes: ['STAT', 'MATH'],
+    faculty: 'Science',
+    sourceUrls: [
+      SOURCE_URLS.science,
+      'https://www.wits.ac.za/science/undergraduate/mathematical-sciences/'
+    ],
+    suggestedCourses: [
+      'Probability Theory',
+      'Mathematical Statistics',
+      'Regression Analysis',
+      'Stochastic Processes',
+      'Data Analysis'
+    ]
+  },
+
+  {
+    degreeName: 'Bachelor of Commerce',
+    aliases: [
+      'BCom',
+      'Bachelor of Commerce',
+      'BCom General',
+      'Commerce',
+      'BCom part-time'
+    ],
+    coursePrefixes: ['ACCN', 'ECON', 'BUSN'],
+    faculty: 'Commerce, Law and Management',
+    isFallback: true,
+    sourceUrls: [SOURCE_URLS.clm],
+    suggestedCourses: [
+      'Financial Accounting',
+      'Economics',
+      'Business Statistics',
+      'Management',
+      'Commercial Law'
+    ]
+  },
+  {
+    degreeName: 'Accounting',
+    aliases: [
+      'BCom Accounting',
+      'Accounting'
+    ],
+    coursePrefixes: ['ACCN', 'AUDT', 'TAX'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/accounting/'
+    ],
+    suggestedCourses: [
+      'Financial Accounting',
+      'Management Accounting',
+      'Auditing',
+      'Taxation',
+      'Commercial Law'
+    ]
+  },
+  {
+    degreeName: 'Accounting Science',
+    aliases: [
+      'BAccSc',
+      'Accounting Science',
+      'Bachelor of Accounting Science'
+    ],
+    coursePrefixes: ['ACCN', 'AUDT', 'TAX'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/accounting-science-baccsc/'
+    ],
+    suggestedCourses: [
+      'Financial Accounting',
+      'Management Accounting and Finance',
+      'Auditing',
+      'Taxation',
+      'Corporate Governance'
+    ]
+  },
+  {
+    degreeName: 'Applied Development Economics',
+    aliases: [
+      'BCom Applied Development Economics',
+      'Applied Development Economics'
+    ],
+    coursePrefixes: ['ECON', 'DEVP', 'STAT'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/applied-development-economics/'
+    ],
+    suggestedCourses: [
+      'Microeconomics',
+      'Macroeconomics',
+      'Development Economics',
+      'Econometrics',
+      'Public Policy'
+    ]
+  },
+  {
+    degreeName: 'Economic Science',
+    aliases: [
+      'BEconSc',
+      'Economic Science',
+      'Bachelor of Economic Science'
+    ],
+    coursePrefixes: ['ECON', 'MATH', 'STAT'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/economic-science/'
+    ],
+    suggestedCourses: [
+      'Mathematical Economics',
+      'Microeconomic Theory',
+      'Macroeconomic Theory',
+      'Econometrics',
+      'Statistical Methods'
+    ]
+  },
+  {
+    degreeName: 'Economics',
+    aliases: [
+      'BCom Economics',
+      'Economics'
+    ],
+    coursePrefixes: ['ECON', 'STAT'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/economics/'
+    ],
+    suggestedCourses: [
+      'Microeconomics',
+      'Macroeconomics',
+      'Econometrics',
+      'Public Economics',
+      'International Trade'
+    ]
+  },
+  {
+    degreeName: 'Financial Sciences',
+    aliases: [
+      'BCom Financial Sciences',
+      'Financial Sciences'
+    ],
+    coursePrefixes: ['FINA', 'ECON', 'DATA'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/bcom-financial-sciences/'
+    ],
+    suggestedCourses: [
+      'Corporate Finance',
+      'Investments',
+      'Financial Modelling',
+      'Fintech',
+      'Economics'
+    ]
+  },
+  {
+    degreeName: 'Finance',
+    aliases: [
+      'BCom Finance',
+      'Finance'
+    ],
+    coursePrefixes: ['FINA', 'ECON', 'RISK'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/finance/'
+    ],
+    suggestedCourses: [
+      'Corporate Finance',
+      'Financial Markets',
+      'Investments',
+      'Portfolio Theory',
+      'Risk Management'
+    ]
+  },
+  {
+    degreeName: 'Human Resource Management',
+    aliases: [
+      'BCom Human Resource Management',
+      'Human Resource Management',
+      'HRM'
+    ],
+    coursePrefixes: ['HRM', 'PSYC', 'MGMT'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/human-resource-management/'
+    ],
+    suggestedCourses: [
+      'Organisational Behaviour',
+      'Labour Relations',
+      'Talent Management',
+      'Compensation Management',
+      'People Analytics'
+    ]
+  },
+  {
+    degreeName: 'Insurance and Risk Management',
+    aliases: [
+      'BCom Insurance and Risk Management',
+      'Insurance and Risk Management',
+      'Risk Management'
+    ],
+    coursePrefixes: ['RISK', 'STAT', 'ACTL'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/insurance-and-risk-management/'
+    ],
+    suggestedCourses: [
+      'Risk Management',
+      'Insurance Principles',
+      'Probability Models',
+      'Loss Modelling',
+      'Enterprise Risk'
+    ]
+  },
+  {
+    degreeName: 'Information Systems',
+    aliases: [
+      'BCom Information Systems',
+      'Information Systems'
+    ],
+    coursePrefixes: ['INFO', 'DATA', 'BUSN'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/information-systems/'
+    ],
+    suggestedCourses: [
+      'Systems Analysis',
+      'Database Design',
+      'Business Process Modelling',
+      'Programming Fundamentals',
+      'IT Governance'
+    ]
+  },
+  {
+    degreeName: 'Management',
+    aliases: [
+      'BCom Management',
+      'Management'
+    ],
+    coursePrefixes: ['MGMT', 'BUSN'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/management/'
+    ],
+    suggestedCourses: [
+      'Strategy',
+      'Operations Management',
+      'Entrepreneurship',
+      'Project Management',
+      'Organisational Behaviour'
+    ]
+  },
+  {
+    degreeName: 'Marketing',
+    aliases: [
+      'BCom Marketing',
+      'Marketing'
+    ],
+    coursePrefixes: ['MKTG', 'BUSN', 'DATA'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/marketing/'
+    ],
+    suggestedCourses: [
+      'Consumer Behaviour',
+      'Brand Management',
+      'Market Research',
+      'Digital Marketing',
+      'Sales Management'
+    ]
+  },
+  {
+    degreeName: 'Politics, Philosophy and Economics',
+    aliases: [
+      'BCom PPE',
+      'Politics Philosophy and Economics',
+      'PPE'
+    ],
+    coursePrefixes: ['PPE', 'ECON', 'PHIL', 'POLS'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/ppe/'
+    ],
+    suggestedCourses: [
+      'Political Theory',
+      'Microeconomics',
+      'Ethics',
+      'Public Policy',
+      'Macroeconomics'
+    ]
+  },
+  {
+    degreeName: 'Bachelor of Commerce with Law',
+    aliases: [
+      'BCom with Law',
+      'BCom part-time with Law',
+      'Commerce with Law'
+    ],
+    coursePrefixes: ['LAW', 'ECON', 'ACCN'],
+    faculty: 'Commerce, Law and Management',
+    sourceUrls: [
+      SOURCE_URLS.clm,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/law/'
+    ],
+    suggestedCourses: [
+      'Commercial Law',
+      'Economics',
+      'Financial Accounting',
+      'Contract',
+      'Corporate Governance'
+    ]
+  },
+  {
+    degreeName: 'Bachelor of Laws',
+    aliases: [
+      'LLB',
+      'Bachelor of Laws',
+      'Law'
+    ],
+    coursePrefixes: ['LAW'],
+    faculty: 'Law',
+    sourceUrls: [
+      SOURCE_URLS.law,
+      'https://www.wits.ac.za/course-finder/undergraduate/clm/llb-law/'
+    ],
+    suggestedCourses: [
+      'Constitutional Law',
+      'Contract',
+      'Criminal Law',
+      'Jurisprudence',
+      'Civil Procedure'
+    ]
+  },
+
+  {
+    degreeName: 'Bachelor of Arts',
+    aliases: [
+      'BA',
+      'Bachelor of Arts',
+      'BA part-time',
+      'Humanities'
+    ],
+    coursePrefixes: ['HUMA', 'SOCI', 'POLS', 'PSYC'],
+    faculty: 'Humanities',
+    isFallback: true,
+    sourceUrls: [SOURCE_URLS.humanities],
+    suggestedCourses: [
+      'Psychology I',
+      'Sociology I',
+      'Political Studies I',
+      'History I',
+      'Media Studies I'
+    ]
+  },
+  {
+    degreeName: 'Bachelor of Arts in Digital Arts',
+    aliases: [
+      'BA Digital Arts',
+      'Humanities Digital Arts'
+    ],
+    coursePrefixes: ['DIGA', 'ARTS', 'COMP'],
+    faculty: 'Humanities',
+    sourceUrls: [
+      SOURCE_URLS.humanities,
+      'https://www.wits.ac.za/course-finder/undergraduate/humanities/digital-arts/'
+    ],
+    suggestedCourses: [
+      'Game Design',
+      'Animation',
+      'Interactive Narrative',
+      'Programming for Digital Arts',
+      'Sound Design'
+    ]
+  },
+  {
+    degreeName: 'Film and Television',
+    aliases: [
+      'BAFT',
+      'Film and Television',
+      'Film Studies',
+      'Television Studies'
+    ],
+    coursePrefixes: ['FILM', 'TV'],
+    faculty: 'Humanities',
+    sourceUrls: [
+      SOURCE_URLS.humanities,
+      'https://www.wits.ac.za/course-finder/undergraduate/humanities/film-and-television/'
+    ],
+    suggestedCourses: [
+      'Screenwriting',
+      'Directing',
+      'Editing',
+      'Production Studies',
+      'Documentary Practice'
+    ]
+  },
+  {
+    degreeName: 'Fine Arts',
+    aliases: [
+      'BAFA',
+      'Fine Arts'
+    ],
+    coursePrefixes: ['ARTS', 'VISA'],
+    faculty: 'Humanities',
+    sourceUrls: [
+      SOURCE_URLS.humanities,
+      'https://www.wits.ac.za/course-finder/undergraduate/humanities/fine-arts/'
+    ],
+    suggestedCourses: [
+      'Studio Practice',
+      'Drawing',
+      'Art History',
+      'Visual Culture',
+      'Critical Theory'
+    ]
+  },
+  {
+    degreeName: 'Bachelor of Education',
+    aliases: [
+      'BEd',
+      'Bachelor of Education',
+      'Foundation Phase Teaching',
+      'Intermediate Phase Teaching',
+      'Senior Phase Teaching',
+      'Further Education and Training Teaching'
+    ],
+    coursePrefixes: ['EDUC', 'PSYC', 'CURR'],
+    faculty: 'Humanities',
+    sourceUrls: [
+      SOURCE_URLS.humanities,
+      'https://www.wits.ac.za/course-finder/undergraduate/humanities/bed-foundation-phase-teaching/',
+      'https://www.wits.ac.za/course-finder/undergraduate/humanities/bed-intermediate-phase-teaching/',
+      'https://www.wits.ac.za/course-finder/undergraduate/humanities/bed-senior-phase-teaching/'
+    ],
+    suggestedCourses: [
+      'Curriculum Studies',
+      'Educational Psychology',
+      'Teaching Practice',
+      'Assessment in Education',
+      'Inclusive Education'
+    ]
+  },
+  {
+    degreeName: 'Music',
+    aliases: [
+      'BMus',
+      'Music'
+    ],
+    coursePrefixes: ['MUSI', 'PERF'],
+    faculty: 'Humanities',
+    sourceUrls: [
+      SOURCE_URLS.humanities,
+      'https://www.wits.ac.za/course-finder/undergraduate/humanities/music/'
+    ],
+    suggestedCourses: [
+      'Music Theory',
+      'Aural Training',
+      'Performance',
+      'Composition',
+      'Musicology'
+    ]
+  },
+  {
+    degreeName: 'Social Work',
+    aliases: [
+      'Bachelor of Social Work',
+      'Social Work'
+    ],
+    coursePrefixes: ['SOWK', 'SOCI'],
+    faculty: 'Humanities',
+    sourceUrls: [
+      SOURCE_URLS.humanities,
+      'https://www.wits.ac.za/course-finder/undergraduate/humanities/social-work/'
+    ],
+    suggestedCourses: [
+      'Social Policy',
+      'Counselling Skills',
+      'Community Development',
+      'Human Behaviour',
+      'Fieldwork Practice'
+    ]
+  },
+  {
+    degreeName: 'Speech-Language Pathology',
+    aliases: [
+      'B Speech',
+      'Speech-Language Pathology',
+      'Speech Language Pathology'
+    ],
+    coursePrefixes: ['SLP', 'LING', 'PSYC'],
+    faculty: 'Humanities',
+    sourceUrls: [
+      SOURCE_URLS.humanities,
+      'https://www.wits.ac.za/course-finder/undergraduate/humanities/speech-language-pathology/'
+    ],
+    suggestedCourses: [
+      'Phonetics',
+      'Language Development',
+      'Speech Disorders',
+      'Clinical Practice',
+      'Neurolinguistics'
+    ]
+  },
+  {
+    degreeName: 'Audiology',
+    aliases: [
+      'B Audiology',
+      'Audiology'
+    ],
+    coursePrefixes: ['AUDI', 'LING'],
+    faculty: 'Humanities',
+    sourceUrls: [
+      SOURCE_URLS.humanities,
+      'https://www.wits.ac.za/course-finder/undergraduate/humanities/audiology/'
+    ],
+    suggestedCourses: [
+      'Anatomy of Hearing',
+      'Audiometry',
+      'Hearing Science',
+      'Diagnostic Audiology',
+      'Aural Rehabilitation'
+    ]
+  },
+  {
+    degreeName: 'Theatre and Performance',
+    aliases: [
+      'BA Theatre and Performance',
+      'Theatre and Performance'
+    ],
+    coursePrefixes: ['DRAM', 'PERF'],
+    faculty: 'Humanities',
+    sourceUrls: [
+      SOURCE_URLS.humanities,
+      'https://www.wits.ac.za/course-finder/undergraduate/humanities/theatre-and-performance/'
+    ],
+    suggestedCourses: [
+      'Acting',
+      'Directing',
+      'Performance Studies',
+      'Stagecraft',
+      'Dramatic Literature'
+    ]
+  },
+  {
+    degreeName: 'Bachelor of Arts with Law',
+    aliases: [
+      'BA with Law',
+      'BA part-time with Law'
+    ],
+    coursePrefixes: ['LAW', 'POLS', 'PHIL'],
+    faculty: 'Humanities',
+    sourceUrls: [
+      SOURCE_URLS.humanities,
+      'https://www.wits.ac.za/course-finder/undergraduate/humanities/law/'
+    ],
+    suggestedCourses: [
+      'Introduction to Law',
+      'Legal Writing',
+      'Political Studies',
+      'Philosophy',
+      'Sociology'
+    ]
+  },
+
+  {
+    degreeName: 'Bachelor of Health Sciences',
+    aliases: [
+      'BHSc',
+      'Bachelor of Health Sciences',
+      'Health Sciences'
+    ],
+    coursePrefixes: ['HEAL', 'BIOM', 'STAT'],
+    faculty: 'Health Sciences',
+    isFallback: true,
+    sourceUrls: [SOURCE_URLS.health],
+    suggestedCourses: [
+      'Human Biology',
+      'Health Systems',
+      'Biostatistics',
+      'Public Health',
+      'Research Methods'
+    ]
+  },
+  {
+    degreeName: 'Biokinetics',
+    aliases: [
+      'BHSc Biokinetics',
+      'Biokinetics'
+    ],
+    coursePrefixes: ['BIOK', 'ANAT', 'PHYSIO'],
+    faculty: 'Health Sciences',
+    sourceUrls: [
+      SOURCE_URLS.health,
+      'https://www.wits.ac.za/course-finder/undergraduate/health/biokinetics/'
+    ],
+    suggestedCourses: [
+      'Exercise Physiology',
+      'Biomechanics',
+      'Health Promotion',
+      'Rehabilitation Practice',
+      'Functional Anatomy'
+    ]
+  },
+  {
+    degreeName: 'Biomedical Sciences',
+    aliases: [
+      'BHSc Biomedical Sciences',
+      'Biomedical Sciences'
+    ],
+    coursePrefixes: ['BIOM', 'ANAT', 'PHSL'],
+    faculty: 'Health Sciences',
+    sourceUrls: [
+      SOURCE_URLS.health,
+      'https://www.wits.ac.za/course-finder/undergraduate/health/biomedical-sciences/'
+    ],
+    suggestedCourses: [
+      'Cell Biology',
+      'Anatomy',
+      'Physiology',
+      'Pathology',
+      'Biochemistry'
+    ]
+  },
+  {
+    degreeName: 'Clinical Medical Practice',
+    aliases: [
+      'BCMP',
+      'Clinical Medical Practice'
+    ],
+    coursePrefixes: ['CLMP', 'MED'],
+    faculty: 'Health Sciences',
+    sourceUrls: [
+      SOURCE_URLS.health,
+      'https://www.wits.ac.za/course-finder/undergraduate/health/clinical-medical-practice/'
+    ],
+    suggestedCourses: [
+      'Clinical Skills',
+      'Primary Care',
+      'Emergency Care',
+      'Diagnostics',
+      'Community Health'
+    ]
+  },
+  {
+    degreeName: 'Dental Science',
+    aliases: [
+      'BDS',
+      'Dental Science',
+      'Dentistry'
+    ],
+    coursePrefixes: ['DENT', 'ORAL'],
+    faculty: 'Health Sciences',
+    sourceUrls: [
+      SOURCE_URLS.health,
+      'https://www.wits.ac.za/course-finder/undergraduate/health/dental-science/'
+    ],
+    suggestedCourses: [
+      'Oral Biology',
+      'Dental Anatomy',
+      'Restorative Dentistry',
+      'Periodontology',
+      'Community Dentistry'
+    ]
+  },
+  {
+    degreeName: 'Health Systems Science',
+    aliases: [
+      'BHSc Health Systems Science',
+      'Health Systems Science',
+      'Public Health'
+    ],
+    coursePrefixes: ['HSSC', 'PUBH', 'STAT'],
+    faculty: 'Health Sciences',
+    sourceUrls: [
+      SOURCE_URLS.health,
+      'https://www.wits.ac.za/course-finder/undergraduate/health/health-systems-science/'
+    ],
+    suggestedCourses: [
+      'Epidemiology',
+      'Health Policy',
+      'Health Economics',
+      'Biostatistics',
+      'Community Health'
+    ]
+  },
+  {
+    degreeName: 'Medicine and Surgery',
+    aliases: [
+      'MBBCh',
+      'Medicine and Surgery',
+      'Medicine'
+    ],
+    coursePrefixes: ['MEDI', 'SURG', 'ANAT'],
+    faculty: 'Health Sciences',
+    sourceUrls: [
+      SOURCE_URLS.health,
+      'https://www.wits.ac.za/course-finder/undergraduate/health/medicine-and-surgery/'
+    ],
+    suggestedCourses: [
+      'Anatomy',
+      'Physiology',
+      'Pharmacology',
+      'Internal Medicine',
+      'Surgery'
+    ]
+  },
+  {
+    degreeName: 'Nursing',
+    aliases: [
+      'BNurs',
+      'Bachelor of Nursing',
+      'Nursing'
+    ],
+    coursePrefixes: ['NURS', 'MIDW'],
+    faculty: 'Health Sciences',
+    sourceUrls: [
+      SOURCE_URLS.health,
+      'https://www.wits.ac.za/course-finder/undergraduate/health/nursing/'
+    ],
+    suggestedCourses: [
+      'General Nursing',
+      'Midwifery',
+      'Community Nursing',
+      'Clinical Practice',
+      'Health Assessment'
+    ]
+  },
+  {
+    degreeName: 'Nursing Systems Science',
+    aliases: [
+      'BHSc Nursing Systems Science',
+      'Nursing Systems Science'
+    ],
+    coursePrefixes: ['NURS', 'HSSC', 'LEAD'],
+    faculty: 'Health Sciences',
+    sourceUrls: [
+      SOURCE_URLS.health,
+      'https://www.wits.ac.za/course-finder/undergraduate/health/nursing-systems-science/'
+    ],
+    suggestedCourses: [
+      'Health Leadership',
+      'Evidence-Based Practice',
+      'Health Systems',
+      'Research Methods',
+      'Professional Practice'
+    ]
+  },
+  {
+    degreeName: 'Occupational Therapy',
+    aliases: [
+      'BSc Occupational Therapy',
+      'BSc OT',
+      'Occupational Therapy'
+    ],
+    coursePrefixes: ['OT', 'REHB'],
+    faculty: 'Health Sciences',
+    sourceUrls: [
+      SOURCE_URLS.health,
+      'https://www.wits.ac.za/course-finder/undergraduate/health/occupational-therapy/'
+    ],
+    suggestedCourses: [
+      'Occupational Performance',
+      'Therapeutic Activities',
+      'Rehabilitation',
+      'Mental Health Practice',
+      'Community Practice'
+    ]
+  },
+  {
+    degreeName: 'Oral Health Sciences',
+    aliases: [
+      'BOHSc',
+      'Oral Health Sciences'
+    ],
+    coursePrefixes: ['ORAL', 'DENT'],
+    faculty: 'Health Sciences',
+    sourceUrls: [
+      SOURCE_URLS.health,
+      'https://www.wits.ac.za/course-finder/undergraduate/health/oral-health-sciences/'
+    ],
+    suggestedCourses: [
+      'Preventive Dentistry',
+      'Oral Anatomy',
+      'Periodontal Care',
+      'Dental Radiography',
+      'Community Oral Health'
+    ]
+  },
+  {
+    degreeName: 'Pharmacy',
+    aliases: [
+      'BPharm',
+      'Pharmacy'
+    ],
+    coursePrefixes: ['PHRM', 'CHEM', 'MEDI'],
+    faculty: 'Health Sciences',
+    sourceUrls: [
+      SOURCE_URLS.health,
+      'https://www.wits.ac.za/course-finder/undergraduate/health/pharmacy/'
+    ],
+    suggestedCourses: [
+      'Pharmaceutics',
+      'Pharmacology',
+      'Medicinal Chemistry',
+      'Clinical Pharmacy',
+      'Pharmacy Practice'
+    ]
+  },
+  {
+    degreeName: 'Physiotherapy',
+    aliases: [
+      'BSc Physiotherapy',
+      'Physiotherapy'
+    ],
+    coursePrefixes: ['PHYSIO', 'ANAT', 'REHB'],
+    faculty: 'Health Sciences',
+    sourceUrls: [
+      SOURCE_URLS.health,
+      'https://www.wits.ac.za/course-finder/undergraduate/health/physiotherapy/'
+    ],
+    suggestedCourses: [
+      'Musculoskeletal Therapy',
+      'Neurological Rehabilitation',
+      'Cardiopulmonary Therapy',
+      'Exercise Therapy',
+      'Clinical Practice'
+    ]
+  }
+]
+
+const WITS_DEGREE_COURSE_TEMPLATES = Object.freeze(DEGREE_TEMPLATE_DEFINITIONS.map(buildTemplate))
+
+const WITS_DEGREE_ALIAS_MAP = WITS_DEGREE_COURSE_TEMPLATES.reduce(function (aliasMap, template) {
+  template.aliases.forEach(function (alias) {
+    if (aliasMap.has(alias)) {
+      throw new Error(`Duplicate degree alias found: ${alias}`)
+    }
+
+    aliasMap.set(alias, template)
+  })
+
+  return aliasMap
+}, new Map())
+
+const getWitsDegreeCourseTemplates = function () {
+  return WITS_DEGREE_COURSE_TEMPLATES
+}
+
+const findWitsDegreeCourseTemplate = function (degreeName) {
+  const normalizedDegreeName = normalizeDegreeName(degreeName)
+
+  if (!normalizedDegreeName) {
+    return null
+  }
+
+  const exactMatch = WITS_DEGREE_ALIAS_MAP.get(normalizedDegreeName)
+
+  if (exactMatch) {
+    return exactMatch
+  }
+
+  let bestMatch = null
+  let bestScore = 0
+
+  WITS_DEGREE_COURSE_TEMPLATES.forEach(function (template) {
+    if (template.isFallback) {
+      return
+    }
+
+    template.aliases.forEach(function (alias) {
+      if (!containsAliasPhrase(normalizedDegreeName, alias) || alias.length <= bestScore) {
+        return
+      }
+
+      bestMatch = template
+      bestScore = alias.length
+    })
+  })
+
+  if (bestMatch) {
+    return bestMatch
+  }
+
+  WITS_DEGREE_COURSE_TEMPLATES.forEach(function (template) {
+    if (!template.isFallback) {
+      return
+    }
+
+    template.aliases.forEach(function (alias) {
+      if (!containsAliasPhrase(normalizedDegreeName, alias) || alias.length <= bestScore) {
+        return
+      }
+
+      bestMatch = template
+      bestScore = alias.length
+    })
+  })
+
+  return bestMatch
+}
+
+module.exports = {
+  findWitsDegreeCourseTemplate,
+  getWitsDegreeCourseTemplates,
+  normalizeDegreeName,
+  SOURCE_URLS,
+  WITS_DEGREE_COURSE_TEMPLATES
+}

--- a/src/services/wits_degree_course_templates.js
+++ b/src/services/wits_degree_course_templates.js
@@ -1477,6 +1477,45 @@ const getWitsDegreeCourseTemplates = function () {
   return WITS_DEGREE_COURSE_TEMPLATES
 }
 
+const buildWitsDegreeTemplateAuditReport = function (degreeNames) {
+  const discoveredDegreeNames = Array.from(new Set(
+    (Array.isArray(degreeNames) ? degreeNames : [])
+      .filter(function (degreeName) {
+        return typeof degreeName === 'string' && degreeName.trim()
+      })
+      .map(function (degreeName) {
+        return degreeName.trim()
+      })
+  ))
+
+  const matched = []
+  const unmatched = []
+
+  discoveredDegreeNames.forEach(function (degreeName) {
+    const template = findWitsDegreeCourseTemplate(degreeName)
+
+    if (!template) {
+      unmatched.push(degreeName)
+      return
+    }
+
+    matched.push({
+      degreeName,
+      faculty: template.faculty,
+      templateDegreeName: template.degreeName
+    })
+  })
+
+  return {
+    degreeCount: discoveredDegreeNames.length,
+    matched,
+    matchedCount: matched.length,
+    templateCount: WITS_DEGREE_COURSE_TEMPLATES.length,
+    unmatched,
+    unmatchedCount: unmatched.length
+  }
+}
+
 const findWitsDegreeCourseTemplate = function (degreeName) {
   const normalizedDegreeName = normalizeDegreeName(degreeName)
 
@@ -1531,6 +1570,7 @@ const findWitsDegreeCourseTemplate = function (degreeName) {
 }
 
 module.exports = {
+  buildWitsDegreeTemplateAuditReport,
   findWitsDegreeCourseTemplate,
   getWitsDegreeCourseTemplates,
   normalizeDegreeName,

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -120,6 +120,66 @@
       </section>
     <% } %>
 
+    <% if (role === 'student' || role === 'admin') { %>
+      <section class="peer_search_section">
+        <h2 class="home_navigation_title">Find a Wits Peer</h2>
+        <p class="home_navigation_text">Search for other Wits users by name, degree, or course.</p>
+
+        <form action="/home" method="get">
+          <div class="search_criteria peer_search_criteria">
+            <label class="search_filter">
+              Degree
+              <input type="text" name="peerDegree" value="<%= peerDegree %>" placeholder="e.g. BSc (Eng) - Electrical Engineering">
+            </label>
+
+            <label class="search_filter">
+              Course
+              <input type="text" name="peerCourse" value="<%= peerCourse %>" placeholder="e.g. ELEN">
+            </label>
+          </div>
+
+          <div class="search_flex peer_search_flex">
+            <label class="search_box">
+              Search
+              <input type="text" name="peerQuery" value="<%= peerQuery %>" placeholder="Name and/or username">
+            </label>
+
+            <button type="submit" class="search_button">Search Peers</button>
+          </div>
+        </form>
+
+        <section class="results">
+          <% if (!hasPeerSearch) { %>
+            <p>Search by name, degree, or course to find other Wits users.</p>
+          <% } else if (peers.length === 0) { %>
+            <p>No peers found.</p>
+          <% } else { %>
+            <% peers.forEach(function (peer) { %>
+              <% const peerName = `${peer.firstName || ''} ${peer.lastName || ''}`.trim() || peer.username %>
+              <% const peerInstitution = [peer.facultyId, peer.schoolId].filter(Boolean).join(', ') %>
+              <% const peerCourses = Array.isArray(peer.coursePreview) ? peer.coursePreview : [] %>
+              <article class="lecturer_result_card peer_result_card">
+                <div class="peer_result_summary">
+                  <a class="lecturer_result_link" href="/user_profile?user=<%= encodeURIComponent(peer.username) %>">
+                    <%= peerName %>
+                  </a>
+                  <p class="peer_result_meta"><strong>Username:</strong> <%= peer.username %></p>
+                  <p class="peer_result_meta"><strong>Degree:</strong> <%= peer.degree || 'Not shared yet' %></p>
+                  <% if (peerInstitution) { %>
+                    <p class="peer_result_meta"><strong>School:</strong> <%= peerInstitution %></p>
+                  <% } %>
+                  <% if (peerCourses.length > 0) { %>
+                    <p class="peer_result_meta"><strong>Courses:</strong> <%= peerCourses.join(', ') %><%= Array.isArray(peer.courses) && peer.courses.length > peerCourses.length ? ' ...' : '' %></p>
+                  <% } %>
+                </div>
+                <a class="button_compact" href="/user_profile?user=<%= encodeURIComponent(peer.username) %>">View Profile</a>
+              </article>
+            <% }) %>
+          <% } %>
+        </section>
+      </section>
+    <% } %>
+
     <section class="calendar_section">
       <h2 class="calendar_title"><%= calendar.monthLabel %></h2>
       <table class="calendar_table">

--- a/src/views/user_profile.ejs
+++ b/src/views/user_profile.ejs
@@ -113,6 +113,56 @@
       </div>
     </section>
 
+    <% if (role !== 'lecturer') { %>
+    <section class="academic_profile_section">
+      <h2 class="consultation_preferences_title">Academic Profile</h2>
+
+      <% if (canEdit) { %>
+      <div class="profile_update_form academic_profile_form" data-save-url="/users/<%= encodeURIComponent(username) %>" data-template-url="/users/academic-template">
+        <label>
+          Degree
+          <input
+            id="academic_profile_degree"
+            type="text"
+            name="degree"
+            value="<%= degree %>"
+            placeholder="e.g. BSc (Eng) - Electrical Engineering"
+            autocomplete="off"
+          >
+        </label>
+
+        <label>
+          Courses
+          <textarea
+            id="academic_profile_courses"
+            class="consult_textarea"
+            name="courses"
+            rows="6"
+            placeholder="Use one course per line"
+          ><%= courses %></textarea>
+        </label>
+
+        <div class="academic_profile_actions">
+          <button id="academic_profile_autofill" type="button">Autofill Courses</button>
+          <button id="academic_profile_save" type="button">Save Academic Profile</button>
+          <p id="academic_profile_status" class="academic_profile_status" aria-live="polite"></p>
+        </div>
+      </div>
+      <% } else { %>
+      <div class="profile_details">
+        <div class="profile_detail">
+          <h3 class="profile_detail_label">Degree</h3>
+          <p class="profile_detail_value"><%= degree || 'Not set' %></p>
+        </div>
+        <div class="profile_detail">
+          <h3 class="profile_detail_label">Courses</h3>
+          <p class="profile_detail_value"><%= courses ? courses.split('\n').join(', ') : 'Not set' %></p>
+        </div>
+      </div>
+      <% } %>
+    </section>
+    <% } %>
+
     <% if (role === 'lecturer') { %>
     <%
       const weeklyAvailability = consultationPreferences && consultationPreferences.weeklyAvailability

--- a/tests/integration/home.test.js
+++ b/tests/integration/home.test.js
@@ -1,9 +1,11 @@
 const http = require('node:http')
 const { closeDatabaseConnection, connectToDatabase, getCollection } = require('../../src/models/db')
+const { hashPassword } = require('../../src/utils/password')
 const app = require('../../src/app')
 
 const LECTURER_USERNAME = 'user1'
 const PASSWORD = 'password'
+const PEER_SEARCH_TEST_USERNAME = `peer-search-${process.pid}`
 const RUN_DB_TEST = process.env.MONGODB_URI ? test : test.skip
 const STUDENT_USERNAME = 'user'
 const TEST_ID = `${process.pid}${Date.now()}`
@@ -50,6 +52,11 @@ const deleteTestConsultations = async function () {
   await getCollection('Consultation').deleteMany({ title: { $regex: `^${TEST_TITLE_PREFIX}` } })
 }
 
+const deletePeerSearchUsers = async function () {
+  await connectToDatabase()
+  await getCollection('User').deleteMany({ username: { $regex: `^${PEER_SEARCH_TEST_USERNAME}` } })
+}
+
 const getFutureCurrentMonthDatetime = function () {
   const future = new Date(Date.now() + 2 * 60 * 60 * 1000)
   const year = future.getFullYear()
@@ -77,16 +84,19 @@ describe('home calendar integration', () => {
   beforeEach(async function () {
     if (!process.env.MONGODB_URI) return
     await deleteTestConsultations()
+    await deletePeerSearchUsers()
   })
 
   afterEach(async function () {
     if (!process.env.MONGODB_URI) return
     await deleteTestConsultations()
+    await deletePeerSearchUsers()
   })
 
   afterAll(async function () {
     if (!process.env.MONGODB_URI) return
     await deleteTestConsultations()
+    await deletePeerSearchUsers()
     await closeServer(server)
     await closeDatabaseConnection()
   })
@@ -183,5 +193,37 @@ describe('home calendar integration', () => {
 
     expect(response.status).toBe(200)
     expect(body).not.toContain(title)
+  })
+
+  RUN_DB_TEST('finds a peer on the home page by course and degree', async function () {
+    await connectToDatabase()
+    const users = getCollection('User')
+    const seededStudent = await users.findOne({ username: STUDENT_USERNAME })
+
+    await users.insertOne({
+      username: `${PEER_SEARCH_TEST_USERNAME}-${TEST_ID}`,
+      passwordHash: await hashPassword('password'),
+      role: 'student',
+      email: `peer-search-${TEST_ID}@example.com`,
+      firstName: 'Amogelang',
+      lastName: 'Maseko',
+      universityId: seededStudent?.universityId || 'University of the Witwatersrand',
+      facultyId: 'Engineering',
+      schoolId: 'Electrical Engineering',
+      degree: 'BSc (Eng) - Electrical Engineering',
+      courses: ['ELEN Circuit Theory', 'ELEN Electronics']
+    })
+
+    const sessionCookie = await loginAs(baseUrl, { password: PASSWORD, username: STUDENT_USERNAME })
+    const response = await fetch(`${baseUrl}/home?peerDegree=Electrical%20Engineering&peerCourse=ELEN`, {
+      headers: { cookie: sessionCookie }
+    })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('Find a Wits Peer')
+    expect(body).toContain('Amogelang Maseko')
+    expect(body).toContain('ELEN Circuit Theory, ELEN Electronics')
+    expect(body).toContain('BSc (Eng) - Electrical Engineering')
   })
 })

--- a/tests/integration/user_profile_page.test.js
+++ b/tests/integration/user_profile_page.test.js
@@ -1,7 +1,7 @@
 const http = require('node:http')
 const { closeDatabaseConnection, connectToDatabase, getCollection } = require('../../src/models/db')
 const { getLecturerAvailability, setLecturerAvailability } = require('../../src/models/lecturer_availability_db')
-const { getUser, updateUserInstitutions } = require('../../src/models/user_db')
+const { getUser, updateUserAcademicProfile, updateUserInstitutions } = require('../../src/models/user_db')
 const app = require('../../src/app')
 
 const FACULTY_NAME = 'Engineering and the Built Environment'
@@ -59,6 +59,7 @@ const loginAs = async function (baseUrl, { password, username }) {
 }
 
 describe('user profile integration flow', () => {
+  let originalStudentAcademicProfile
   let baseUrl
   let originalLecturerPreferences
   let originalStudentInstitutions
@@ -76,6 +77,10 @@ describe('user profile integration flow', () => {
       facultyId: originalStudent?.facultyId || FACULTY_NAME,
       schoolId: originalStudent?.schoolId || SCHOOL_NAME,
       universityId: originalStudent?.universityId || UNIVERSITY_NAME
+    }
+    originalStudentAcademicProfile = {
+      courses: originalStudent?.courses || [],
+      degree: originalStudent?.degree || ''
     }
     originalLecturerPreferences = await getLecturerAvailability(LECTURER_USERNAME)
 
@@ -104,6 +109,7 @@ describe('user profile integration flow', () => {
     }
 
     await connectToDatabase()
+    await updateUserAcademicProfile(STUDENT_USERNAME, originalStudentAcademicProfile)
     await updateUserInstitutions(STUDENT_USERNAME, originalStudentInstitutions)
 
     if (originalLecturerPreferences) {
@@ -142,8 +148,46 @@ describe('user profile integration flow', () => {
     expect(body).toContain('test@email.com')
     expect(body).toContain('Engineering and the Built Environment')
     expect(body).toContain('Electrical and Information Engineering')
+    expect(body).toContain('Academic Profile')
+    expect(body).toContain('Autofill Courses')
+    expect(body).toContain('Save Academic Profile')
+    expect(body).toContain('e.g. BSc (Eng) - Electrical Engineering')
+    expect(body).toContain('Use one course per line')
     expect(body).toContain('Update Institution')
     expect(body).not.toContain('Consultation Preferences')
+  })
+
+  RUN_DB_TEST('saves academic profile details for the seeded profile owner', async function () {
+    const sessionCookie = await loginAs(baseUrl, {
+      password: STUDENT_PASSWORD,
+      username: STUDENT_USERNAME
+    })
+    const response = await fetch(`${baseUrl}/users/${STUDENT_USERNAME}`, {
+      body: encodeForm({
+        courses: 'ELEN Circuit Theory\nELEN Electronics\nELEN Signals and Systems',
+        degree: 'BSc (Eng) - Electrical Engineering'
+      }),
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: sessionCookie
+      },
+      method: 'PATCH'
+    })
+    const data = await response.json()
+    const updatedUser = await getUser(STUDENT_USERNAME)
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({
+      profile: {
+        courses: ['ELEN Circuit Theory', 'ELEN Electronics', 'ELEN Signals and Systems'],
+        degree: 'BSc (Eng) - Electrical Engineering'
+      },
+      success: true
+    })
+    expect(updatedUser).toEqual(expect.objectContaining({
+      courses: ['ELEN Circuit Theory', 'ELEN Electronics', 'ELEN Signals and Systems'],
+      degree: 'BSc (Eng) - Electrical Engineering'
+    }))
   })
 
   RUN_DB_TEST('renders the seeded lecturer profile with consultation preferences controls', async function () {

--- a/tests/unit/models/user_db.test.js
+++ b/tests/unit/models/user_db.test.js
@@ -13,6 +13,7 @@ const {
   getUserByGoogleId,
   linkGoogleId,
   searchLecturers,
+  searchUsersByAcademicProfile,
   updateUserAcademicProfile,
   updateUserInstitutions
 } = require('../../../src/models/user_db')
@@ -239,5 +240,48 @@ describe('user database operations', () => {
     expect(filter.$or[3].lastName.source).toBe('Smith\\?')
     expect(filter.$or[4].firstName.source).toBe('Smith\\?')
     expect(filter.$or[4].lastName.source).toBe('Alice\\.\\*')
+  })
+
+  test('searchUsersByAcademicProfile filters non-lecturer users within a university', async () => {
+    const peers = [{ username: 'alice', degree: 'BSc (Eng) - Electrical Engineering' }]
+    findCursor.toArray.mockResolvedValue(peers)
+
+    const result = await searchUsersByAcademicProfile({
+      excludeUsername: 'morris',
+      universityId: 'University of the Witwatersrand'
+    })
+
+    expect(mockCollection.find).toHaveBeenCalledWith({
+      role: { $in: ['admin', 'student'] },
+      universityId: 'University of the Witwatersrand',
+      username: { $ne: 'morris' }
+    })
+    expect(result).toEqual(peers)
+  })
+
+  test('searchUsersByAcademicProfile adds degree, course, and name filters', async () => {
+    findCursor.toArray.mockResolvedValue([])
+
+    await searchUsersByAcademicProfile({
+      course: 'ELEN.*',
+      degree: 'Electrical Engineering?',
+      excludeUsername: 'morris',
+      query: 'Alice Smith',
+      universityId: 'University of the Witwatersrand'
+    })
+
+    const filter = mockCollection.find.mock.calls[0][0]
+
+    expect(filter).toMatchObject({
+      role: { $in: ['admin', 'student'] },
+      universityId: 'University of the Witwatersrand',
+      username: { $ne: 'morris' }
+    })
+    expect(filter.degree.source).toBe('Electrical Engineering\\?')
+    expect(filter.courses.source).toBe('ELEN\\.\\*')
+    expect(filter.$or).toHaveLength(5)
+    expect(filter.$or[0].username.source).toBe('Alice Smith')
+    expect(filter.$or[3].firstName.source).toBe('Alice')
+    expect(filter.$or[3].lastName.source).toBe('Smith')
   })
 })

--- a/tests/unit/models/user_db.test.js
+++ b/tests/unit/models/user_db.test.js
@@ -13,6 +13,7 @@ const {
   getUserByGoogleId,
   linkGoogleId,
   searchLecturers,
+  updateUserAcademicProfile,
   updateUserInstitutions
 } = require('../../../src/models/user_db')
 
@@ -76,6 +77,28 @@ describe('user database operations', () => {
           facultyId: 'Engineering',
           schoolId: 'EIE',
           universityId: 'University of the Witwatersrand'
+        }
+      }
+    )
+    expect(result).toEqual(updateResult)
+  })
+
+  test('updateUserAcademicProfile updates degree and courses by username', async () => {
+    const updateResult = { acknowledged: true, modifiedCount: 1 }
+    mockCollection.updateOne.mockResolvedValue(updateResult)
+
+    const result = await updateUserAcademicProfile('morris', {
+      courses: ['ELEN Circuit Theory', 'ELEN Electronics'],
+      degree: 'BSc (Eng) - Electrical Engineering'
+    })
+
+    expect(getCollection).toHaveBeenCalledWith('User')
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      { username: 'morris' },
+      {
+        $set: {
+          courses: ['ELEN Circuit Theory', 'ELEN Electronics'],
+          degree: 'BSc (Eng) - Electrical Engineering'
         }
       }
     )

--- a/tests/unit/routes/home.test.js
+++ b/tests/unit/routes/home.test.js
@@ -16,7 +16,8 @@ jest.mock('../../../src/models/user_db', () => ({
   deleteUser: jest.fn(),
   getLecturersByUsernames: jest.fn(),
   getUser: jest.fn(),
-  searchLecturers: jest.fn()
+  searchLecturers: jest.fn(),
+  searchUsersByAcademicProfile: jest.fn()
 }))
 
 jest.mock('../../../src/models/consultation_db', () => ({
@@ -60,7 +61,7 @@ const closeServer = async function (server) {
 
 const { connectToDatabase } = require('../../../src/models/db')
 const { getLecturerAvailability } = require('../../../src/models/lecturer_availability_db')
-const { getLecturersByUsernames, getUser, searchLecturers } = require('../../../src/models/user_db')
+const { getLecturersByUsernames, getUser, searchLecturers, searchUsersByAcademicProfile } = require('../../../src/models/user_db')
 const { addConsultation, getConsultationsForCalendar, getUpcomingConsultationsForFollowedLecturers, getUpcomingConsultationsForLecturer } = require('../../../src/models/consultation_db')
 const { hashPassword } = require('../../../src/utils/password')
 const app = require('../../../src/app')
@@ -80,6 +81,27 @@ const MOCK_LECTURERS = [
 const MOCK_LECTURERS_21 = Array.from({ length: 21 }, function (_, i) {
   return { username: `lecturer${i}`, firstName: `First${i}`, lastName: `Last${i}`, facultyId: 'Engineering', schoolId: 'EIE' }
 })
+
+const MOCK_PEERS = [
+  {
+    username: 'amy',
+    firstName: 'Amy',
+    lastName: 'Ndlovu',
+    facultyId: 'Engineering',
+    schoolId: 'Electrical Engineering',
+    degree: 'BSc (Eng) - Electrical Engineering',
+    courses: ['ELEN Circuit Theory', 'ELEN Electronics', 'ELEN Signals and Systems']
+  },
+  {
+    username: 'busi',
+    firstName: 'Busi',
+    lastName: 'Mokoena',
+    facultyId: 'Engineering',
+    schoolId: 'Electrical Engineering',
+    degree: 'BSc (Eng) - Electrical Engineering',
+    courses: ['ELEN Energy Conversion']
+  }
+]
 
 const MOCK_FOLLOWED_CONSULTATIONS = [
   {
@@ -194,6 +216,7 @@ describe('home route', () => {
     getLecturerAvailability.mockResolvedValue(null)
     getUser.mockResolvedValue({ followedLecturers: [], role: 'student', username: 'morris' })
     searchLecturers.mockResolvedValue([])
+    searchUsersByAcademicProfile.mockResolvedValue([])
   })
 
   test('Redirects unauthenticated users to login when requesting the home page', async () => {
@@ -583,6 +606,73 @@ describe('home route', () => {
     expect(response.status).toBe(200)
     expect(body).toContain('Alice Smith')
     expect(body).toContain('Bob Jones')
+  })
+
+  test('Renders peer search controls for student-like users', async () => {
+    const { sessionCookie } = await loginAs({ role: 'student', username: 'testuser' })
+    const response = await fetch(`${baseUrl}/home`, {
+      headers: { cookie: sessionCookie }
+    })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('Find a Wits Peer')
+    expect(body).toContain('name="peerDegree"')
+    expect(body).toContain('name="peerCourse"')
+    expect(body).toContain('name="peerQuery"')
+    expect(searchUsersByAcademicProfile).not.toHaveBeenCalled()
+  })
+
+  test('Passes peer search filters to searchUsersByAcademicProfile', async () => {
+    const { sessionCookie } = await loginAs({ role: 'student', username: 'testuser', universityId: 'Wits' })
+
+    await fetch(`${baseUrl}/home?peerDegree=Electrical%20Engineering&peerCourse=ELEN&peerQuery=amy`, {
+      headers: { cookie: sessionCookie }
+    })
+
+    expect(searchUsersByAcademicProfile).toHaveBeenCalledWith({
+      course: 'ELEN',
+      degree: 'Electrical Engineering',
+      excludeUsername: 'testuser',
+      query: 'amy',
+      universityId: 'Wits'
+    })
+  })
+
+  test('Renders peer search results with degree and course details', async () => {
+    searchUsersByAcademicProfile.mockResolvedValue(MOCK_PEERS)
+    const { sessionCookie } = await loginAs({ role: 'student', username: 'testuser', universityId: 'Wits' })
+    const response = await fetch(`${baseUrl}/home?peerCourse=ELEN`, {
+      headers: { cookie: sessionCookie }
+    })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('Amy Ndlovu')
+    expect(body).toContain('BSc (Eng) - Electrical Engineering')
+    expect(body).toContain('ELEN Circuit Theory, ELEN Electronics, ELEN Signals and Systems')
+    expect(body).toContain('href="/user_profile?user=amy"')
+  })
+
+  test('Returns peer search results in JSON when requested', async () => {
+    searchUsersByAcademicProfile.mockResolvedValue(MOCK_PEERS)
+    const { sessionCookie } = await loginAs({ role: 'student', username: 'testuser', universityId: 'Wits' })
+    const response = await fetch(`${baseUrl}/home?peerCourse=ELEN`, {
+      headers: { cookie: sessionCookie, accept: 'application/json' }
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.peers).toEqual([
+      expect.objectContaining({
+        username: 'amy',
+        coursePreview: ['ELEN Circuit Theory', 'ELEN Electronics', 'ELEN Signals and Systems']
+      }),
+      expect.objectContaining({
+        username: 'busi',
+        coursePreview: ['ELEN Energy Conversion']
+      })
+    ])
   })
 
   test('Passes the search query string to searchLecturers', async () => {

--- a/tests/unit/routes/register_complete.test.js
+++ b/tests/unit/routes/register_complete.test.js
@@ -250,6 +250,8 @@ describe('register_complete route', () => {
     expect(response.status).toBe(302)
     expect(response.headers.get('location')).toBe('/home')
     expect(addUser).toHaveBeenCalledWith(expect.objectContaining({
+      courses: [],
+      degree: '',
       googleId: MOCK_PENDING_GOOGLE.googleId,
       email: MOCK_PENDING_GOOGLE.email,
       username: 'alice',
@@ -257,6 +259,40 @@ describe('register_complete route', () => {
     }))
     expect(addUser).toHaveBeenCalledWith(expect.not.objectContaining({
       passwordHash: expect.anything()
+    }))
+  })
+
+  test('POST /register creates a local user with empty academic defaults', async () => {
+    const response = await fetch(`${baseUrl}/register`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: encodeForm({
+        emailAddress: 'sam@example.com',
+        username: 'sam',
+        password: 'welovesd3',
+        university: 'Wits',
+        faculty: 'Engineering',
+        school: 'EIE',
+        role: 'student',
+        name: 'Sam',
+        surname: 'Ndlovu'
+      }),
+      redirect: 'manual'
+    })
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('/login')
+    expect(addUser).toHaveBeenCalledWith(expect.objectContaining({
+      courses: [],
+      degree: '',
+      email: 'sam@example.com',
+      firstName: 'Sam',
+      lastName: 'Ndlovu',
+      passwordHash: expect.any(String),
+      role: 'student',
+      username: 'sam'
     }))
   })
 

--- a/tests/unit/routes/users.test.js
+++ b/tests/unit/routes/users.test.js
@@ -4,7 +4,8 @@ jest.mock('../../../src/models/db', () => ({
 
 jest.mock('../../../src/models/user_db', () => ({
   followLecturer: jest.fn(),
-  getUser: jest.fn()
+  getUser: jest.fn(),
+  updateUserAcademicProfile: jest.fn()
 }))
 
 const http = require('node:http')
@@ -12,7 +13,7 @@ const express = require('express')
 
 const { connectToDatabase } = require('../../../src/models/db')
 const requireAuthentication = require('../../../src/middleware/require_authentication')
-const { followLecturer, getUser } = require('../../../src/models/user_db')
+const { followLecturer, getUser, updateUserAcademicProfile } = require('../../../src/models/user_db')
 const usersRouter = require('../../../src/routes/users')
 
 const closeServer = async function (server) {
@@ -93,6 +94,7 @@ describe('users route', () => {
     connectToDatabase.mockResolvedValue(undefined)
     getUser.mockResolvedValue({ firstName: 'Alice', lastName: 'Smith', role: 'lecturer', universityId: 'Wits', username: 'lecturer1' })
     followLecturer.mockResolvedValue({ acknowledged: true, matchedCount: 1, modifiedCount: 1 })
+    updateUserAcademicProfile.mockResolvedValue({ acknowledged: true, matchedCount: 1, modifiedCount: 1 })
   })
 
   test('redirects unauthenticated users to login', async () => {
@@ -139,6 +141,74 @@ describe('users route', () => {
     expect(unknownResponse.status).toBe(200)
     expect(unknownData).toEqual({ matched: false, template: null })
     expect(connectToDatabase).not.toHaveBeenCalled()
+  })
+
+  test('updates an authenticated users academic profile', async () => {
+    const response = await fetch(`${baseUrl}/users/morris`, {
+      body: new URLSearchParams({
+        courses: 'ELEN Circuit Theory\nELEN Electronics',
+        degree: 'BSc (Eng) - Electrical Engineering'
+      }),
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      method: 'PATCH'
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({
+      profile: {
+        courses: ['ELEN Circuit Theory', 'ELEN Electronics'],
+        degree: 'BSc (Eng) - Electrical Engineering'
+      },
+      success: true
+    })
+    expect(connectToDatabase).toHaveBeenCalledTimes(1)
+    expect(updateUserAcademicProfile).toHaveBeenCalledWith('morris', {
+      courses: ['ELEN Circuit Theory', 'ELEN Electronics'],
+      degree: 'BSc (Eng) - Electrical Engineering'
+    })
+  })
+
+  test('autofills academic profile courses from a known Wits degree when courses are blank', async () => {
+    const response = await fetch(`${baseUrl}/users/morris`, {
+      body: new URLSearchParams({
+        courses: '',
+        degree: 'BSc (Eng) - Electrical Engineering'
+      }),
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      method: 'PATCH'
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.profile.courses).toEqual(expect.arrayContaining([
+      'ELEN Circuit Theory',
+      'ELEN Electronics',
+      'ELEN Signals and Systems'
+    ]))
+  })
+
+  test('rejects attempts to update another users academic profile', async () => {
+    const response = await fetch(`${baseUrl}/users/alice`, {
+      body: new URLSearchParams({
+        courses: 'ELEN Circuit Theory',
+        degree: 'BSc (Eng) - Electrical Engineering'
+      }),
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      method: 'PATCH'
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data).toEqual({ error: 'You can only update your own academic profile.', success: false })
+    expect(connectToDatabase).not.toHaveBeenCalled()
+    expect(updateUserAcademicProfile).not.toHaveBeenCalled()
   })
 
   test('rejects authenticated non-student users', async () => {

--- a/tests/unit/routes/users.test.js
+++ b/tests/unit/routes/users.test.js
@@ -109,6 +109,38 @@ describe('users route', () => {
     expect(connectToDatabase).not.toHaveBeenCalled()
   })
 
+  test('returns an autofill template for a known Wits degree', async () => {
+    const response = await fetch(`${baseUrl}/users/academic-template?degree=${encodeURIComponent('BSc (Eng) - Electrical Engineering')}`)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(expect.objectContaining({
+      matched: true,
+      template: expect.objectContaining({
+        coursePrefixes: expect.arrayContaining(['ELEN']),
+        courses: expect.arrayContaining(['ELEN Circuit Theory', 'ELEN Electronics']),
+        degreeName: 'Electrical Engineering',
+        faculty: 'Engineering and the Built Environment'
+      })
+    }))
+    expect(connectToDatabase).not.toHaveBeenCalled()
+  })
+
+  test('returns no template when the degree query is blank or unknown', async () => {
+    const blankResponse = await fetch(`${baseUrl}/users/academic-template`)
+    const blankData = await blankResponse.json()
+
+    expect(blankResponse.status).toBe(200)
+    expect(blankData).toEqual({ matched: false, template: null })
+
+    const unknownResponse = await fetch(`${baseUrl}/users/academic-template?degree=${encodeURIComponent('Bachelor of Portal Magic')}`)
+    const unknownData = await unknownResponse.json()
+
+    expect(unknownResponse.status).toBe(200)
+    expect(unknownData).toEqual({ matched: false, template: null })
+    expect(connectToDatabase).not.toHaveBeenCalled()
+  })
+
   test('rejects authenticated non-student users', async () => {
     currentSessionUser = {
       role: 'lecturer',

--- a/tests/unit/services/wits_degree_course_templates.test.js
+++ b/tests/unit/services/wits_degree_course_templates.test.js
@@ -1,4 +1,5 @@
 const {
+  buildWitsDegreeTemplateAuditReport,
   findWitsDegreeCourseTemplate,
   getWitsDegreeCourseTemplates,
   normalizeDegreeName,
@@ -60,5 +61,31 @@ describe('wits degree course templates', () => {
 
     expect(scienceTemplate.degreeName).toBe('Bachelor of Science')
     expect(healthTemplate.degreeName).toBe('Bachelor of Health Sciences')
+  })
+
+  test('builds an audit report for discovered Wits programme labels', () => {
+    const auditReport = buildWitsDegreeTemplateAuditReport([
+      'BSc (Eng) - Electrical Engineering',
+      'Bachelor of Commerce in Finance',
+      'Bachelor of Portal Magic',
+      'Bachelor of Commerce in Finance'
+    ])
+
+    expect(auditReport.degreeCount).toBe(3)
+    expect(auditReport.matchedCount).toBe(2)
+    expect(auditReport.unmatchedCount).toBe(1)
+    expect(auditReport.matched).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        degreeName: 'BSc (Eng) - Electrical Engineering',
+        faculty: 'Engineering and the Built Environment',
+        templateDegreeName: 'Electrical Engineering'
+      }),
+      expect.objectContaining({
+        degreeName: 'Bachelor of Commerce in Finance',
+        faculty: 'Commerce, Law and Management',
+        templateDegreeName: 'Finance'
+      })
+    ]))
+    expect(auditReport.unmatched).toEqual(['Bachelor of Portal Magic'])
   })
 })

--- a/tests/unit/services/wits_degree_course_templates.test.js
+++ b/tests/unit/services/wits_degree_course_templates.test.js
@@ -1,0 +1,64 @@
+const {
+  findWitsDegreeCourseTemplate,
+  getWitsDegreeCourseTemplates,
+  normalizeDegreeName,
+  WITS_DEGREE_COURSE_TEMPLATES
+} = require('../../../src/services/wits_degree_course_templates')
+
+describe('wits degree course templates', () => {
+  test('normalizes degree names consistently', () => {
+    expect(normalizeDegreeName('BSc (Eng) - Electrical Engineering')).toBe('bsc eng electrical engineering')
+    expect(normalizeDegreeName('  Bachelor of Arts & Law  ')).toBe('bachelor of arts and law')
+    expect(normalizeDegreeName(null)).toBe('')
+  })
+
+  test('contains a broad catalogue of Wits degree templates', () => {
+    const templates = getWitsDegreeCourseTemplates()
+
+    expect(templates).toBe(WITS_DEGREE_COURSE_TEMPLATES)
+    expect(templates.length).toBeGreaterThanOrEqual(40)
+
+    templates.forEach(function (template) {
+      expect(template.degreeName).toEqual(expect.any(String))
+      expect(template.faculty).toEqual(expect.any(String))
+      expect(template.lastUpdated).toBe('2026-05-17')
+      expect(Array.isArray(template.aliases)).toBe(true)
+      expect(template.aliases.length).toBeGreaterThan(0)
+      expect(Array.isArray(template.sourceUrls)).toBe(true)
+      expect(template.sourceUrls.length).toBeGreaterThan(0)
+      expect(Array.isArray(template.suggestedCourses)).toBe(true)
+      expect(template.suggestedCourses.length).toBeGreaterThanOrEqual(5)
+    })
+  })
+
+  test('matches electrical engineering to ELEN-heavy autofill data', () => {
+    const template = findWitsDegreeCourseTemplate('BSc (Eng) - Electrical Engineering')
+
+    expect(template).toEqual(expect.objectContaining({
+      degreeName: 'Electrical Engineering',
+      faculty: 'Engineering and the Built Environment'
+    }))
+    expect(template.coursePrefixes).toContain('ELEN')
+    expect(template.suggestedCourses).toEqual(expect.arrayContaining([
+      'ELEN Circuit Theory',
+      'ELEN Electronics',
+      'ELEN Signals and Systems'
+    ]))
+  })
+
+  test('prefers specific matches before generic faculty-level fallbacks', () => {
+    const specificTemplate = findWitsDegreeCourseTemplate('Bachelor of Commerce in Finance')
+    const genericTemplate = findWitsDegreeCourseTemplate('Bachelor of Commerce in Unlisted Major')
+
+    expect(specificTemplate.degreeName).toBe('Finance')
+    expect(genericTemplate.degreeName).toBe('Bachelor of Commerce')
+  })
+
+  test('falls back to umbrella templates when a degree family is known but the field is not modelled', () => {
+    const scienceTemplate = findWitsDegreeCourseTemplate('Bachelor of Science in Astrobiology')
+    const healthTemplate = findWitsDegreeCourseTemplate('Bachelor of Health Sciences in Global Health')
+
+    expect(scienceTemplate.degreeName).toBe('Bachelor of Science')
+    expect(healthTemplate.degreeName).toBe('Bachelor of Health Sciences')
+  })
+})


### PR DESCRIPTION
Closes #71 

**Summary:** Add Wits academic-profile autofill and peer search. Non-lecturer users can save degree and course details, autofill courses from a curated Wits catalogue, and find relevant peers. This also adds registration defaults, a catalogue refresh command, and test coverage.

**Key Changes:**

- Added a curated Wits degree/course template catalogue with alias matching and fallback support.
- Added academic profile autofill and persistence for non-lecturer users.
- Added peer search on the home page by name, degree, and course.
- Defaulted new local and Google-registered users to empty academic fields.
- Added `npm run refresh:wits-degree-templates` and updated unit and integration tests.

**Acceptance:**

- Non-lecturer users can save degree and course details.
- Recognised Wits degrees autofill suggested courses.
- Peer search works by name, degree, and course.
- New accounts start with empty academic fields.

**How to test locally:**

- `npm test`
- `npm run lint`
- `npx jest tests/unit/routes/register_complete.test.js --runInBand`
- `npx jest tests/unit/services/wits_degree_course_templates.test.js --runInBand`
- `npx jest tests/unit/routes/home.test.js --runInBand`
- `npx jest tests/integration/user_profile_page.test.js --config tests/integration/jest.config.js --runInBand`
- `npx jest tests/integration/home.test.js --config tests/integration/jest.config.js --runInBand`
- `npm run refresh:wits-degree-templates`

**Notes:**

- Autofill uses a curated local Wits catalogue rather than live request-time scraping.
- The refresh command requires network access.
- DB-backed integration tests require a writable MongoDB test database.